### PR TITLE
feat: improve accessibility, lazy-load expense dialog, and allow Google Fonts in CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' https://accounts.google.com https://*.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://accounts.google.com https://www.googleapis.com; frame-src 'self' https://accounts.google.com https://*.google.com; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests"
+    Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' https://accounts.google.com https://*.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://accounts.google.com https://www.googleapis.com; frame-src 'self' https://accounts.google.com https://*.google.com; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
     X-Content-Type-Options = "nosniff"
     X-Frame-Options = "DENY"

--- a/src/components/plans/PlanCard.test.ts
+++ b/src/components/plans/PlanCard.test.ts
@@ -87,7 +87,8 @@ const renderPlanCard = (
         'q-card-section': { template: '<div><slot /></div>' },
         'q-card-actions': { template: '<div><slot /></div>' },
         'q-btn': {
-          template: '<button @click="$emit(\'click\')"><slot /></button>',
+          template:
+            '<button class="q-btn" v-bind="$attrs" @click.stop="$emit(\'click\', $event)"><slot /></button>',
           props: ['flat', 'label', 'color', 'unelevated'],
           emits: ['click'],
         },
@@ -159,6 +160,27 @@ describe('PlanCard', () => {
 
     expect(wrapper.emitted('edit')).toBeTruthy()
     expect(wrapper.emitted('edit')?.[0]).toEqual([mockPlan.id])
+  })
+
+  it('should set an accessible name on the overflow actions button', () => {
+    const wrapper = renderPlanCard({
+      plan: mockPlan,
+    })
+
+    const actionsButton = wrapper.find('button[aria-label="Actions for Test Plan"]')
+    expect(actionsButton.exists()).toBe(true)
+    expect(actionsButton.attributes('aria-haspopup')).toBe('menu')
+  })
+
+  it('should not emit edit when the overflow actions button is clicked', async () => {
+    const wrapper = renderPlanCard({
+      plan: mockPlan,
+    })
+
+    const actionsButton = wrapper.find('button[aria-label="Actions for Test Plan"]')
+    await actionsButton.trigger('click')
+
+    expect(wrapper.emitted('edit')).toBeFalsy()
   })
 
   it('should emit share event when menu emits share', () => {

--- a/src/components/plans/PlanCard.vue
+++ b/src/components/plans/PlanCard.vue
@@ -42,6 +42,8 @@
               size="sm"
               icon="eva-more-vertical-outline"
               class="text-grey-7"
+              :aria-label="menuButtonLabel"
+              aria-haspopup="menu"
               @click.stop
             >
               <PlanCardMenu
@@ -155,6 +157,7 @@ const isOwner = computed(() => props.plan.owner_id === userStore.userProfile?.id
 const canEdit = computed(() => isOwner.value || props.plan.permission_level === 'edit')
 const planStatus = computed(() => getPlanStatus(props.plan))
 const isViewOnly = computed(() => props.plan.permission_level === 'view')
+const menuButtonLabel = computed(() => `Actions for ${props.plan.name}`)
 
 function formatAmount(amount: number | null | undefined): string {
   const currency = props.plan.currency as CurrencyCode

--- a/src/components/shared/ItemsGroup.test.ts
+++ b/src/components/shared/ItemsGroup.test.ts
@@ -41,6 +41,16 @@ describe('ItemsGroup', () => {
     expect(wrapper.find('.chip').text()).toContain('2')
   })
 
+  it('renders the cards container as a list with presentational wrappers', () => {
+    const wrapper = renderComponent({ items: [{ id: '1' }, { id: '2' }], title: 'Group' })
+
+    const list = wrapper.find('[role="list"]')
+    const presentations = wrapper.findAll('[role="presentation"]')
+
+    expect(list.exists()).toBe(true)
+    expect(presentations).toHaveLength(2)
+  })
+
   it('renders one card per item and passes slot props', () => {
     const items = [
       { id: 'a', name: 'Alpha' },

--- a/src/components/shared/ItemsGroup.vue
+++ b/src/components/shared/ItemsGroup.vue
@@ -20,11 +20,13 @@
   <div
     class="row"
     :class="$q.screen.lt.md ? 'q-col-gutter-sm' : 'q-col-gutter-md'"
+    role="list"
   >
     <div
       v-for="item in items"
       :key="item.id"
       class="col-12 col-sm-6 col-md-4"
+      role="presentation"
     >
       <slot
         name="item-card"

--- a/src/layouts/MainLayout.test.ts
+++ b/src/layouts/MainLayout.test.ts
@@ -1,9 +1,10 @@
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest'
 import { createTestingPinia } from '@pinia/testing'
 import { vi, it, expect, beforeEach } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { ref } from 'vue'
+import { Screen } from 'quasar'
 
 import MainLayout from './MainLayout.vue'
 
@@ -26,6 +27,16 @@ vi.mock('src/composables/usePwaInstall', () => ({
 }))
 
 type MainLayoutProps = ComponentProps<typeof MainLayout>
+
+function setScreenWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+
+  window.dispatchEvent(new Event('resize'))
+}
 
 const renderMainLayout = (props: MainLayoutProps = {}) => {
   const pinia = createTestingPinia({
@@ -65,14 +76,23 @@ const renderMainLayout = (props: MainLayoutProps = {}) => {
           template: '<div data-testid="navigation-drawer" :items="items" />',
           props: ['items'],
         },
-        MobileBottomNavigation: true,
-        ExpenseRegistrationDialog: true,
+        MobileBottomNavigation: {
+          template:
+            '<button data-testid="mobile-bottom-navigation" @click="$emit(\'open-expense-dialog\')" />',
+          emits: ['open-expense-dialog'],
+        },
+        ExpenseRegistrationDialog: {
+          template: '<div data-testid="expense-dialog" />',
+          props: ['modelValue', 'autoSelectRecentPlan'],
+        },
       },
     },
   })
 }
 
 beforeEach(() => {
+  Screen.setDebounce(0)
+  setScreenWidth(1280)
   vi.clearAllMocks()
 })
 
@@ -122,6 +142,21 @@ it('should render QDrawer with NavigationDrawer', () => {
 
 it('should not render expense dialog by default', () => {
   const wrapper = renderMainLayout()
-  const expenseDialog = wrapper.findComponent({ name: 'ExpenseRegistrationDialog' })
+  const expenseDialog = wrapper.find('[data-testid="expense-dialog"]')
   expect(expenseDialog.exists()).toBe(false)
+})
+
+it('should load expense dialog only after the mobile expense action is triggered', async () => {
+  setScreenWidth(600)
+
+  const wrapper = renderMainLayout()
+  const mobileBottomNavigation = wrapper.find('[data-testid="mobile-bottom-navigation"]')
+
+  expect(mobileBottomNavigation.exists()).toBe(true)
+  expect(wrapper.find('[data-testid="expense-dialog"]').exists()).toBe(false)
+
+  await mobileBottomNavigation.trigger('click')
+  await flushPromises()
+
+  expect(wrapper.find('[data-testid="expense-dialog"]').exists()).toBe(true)
 })

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -67,14 +67,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useQuasar, useMeta, Notify } from 'quasar'
 
 import PrivacyModeToggle from 'src/components/PrivacyModeToggle.vue'
 import NavigationDrawer from 'src/components/NavigationDrawer.vue'
 import MobileBottomNavigation from 'src/components/MobileBottomNavigation.vue'
-import ExpenseRegistrationDialog from 'src/components/expenses/ExpenseRegistrationDialog.vue'
 import { useUserStore } from 'src/stores/user'
 import { usePwaInstall } from 'src/composables/usePwaInstall'
 
@@ -86,6 +85,9 @@ const userStore = useUserStore()
 const route = useRoute()
 const $q = useQuasar()
 const { isInstallable, promptInstall, dismissInstall } = usePwaInstall()
+const ExpenseRegistrationDialog = defineAsyncComponent(
+  () => import('src/components/expenses/ExpenseRegistrationDialog.vue'),
+)
 
 const hasOpenedExpenseDialog = ref(false)
 const showExpenseDialog = ref(false)


### PR DESCRIPTION
- PlanCard: add aria-label and aria-haspopup on overflow actions button for screen readers
- ItemsGroup: add role=list and role=presentation for proper list semantics
- MainLayout: lazy-load ExpenseRegistrationDialog so it only loads when the user taps the mobile expense FAB
- netlify.toml: add fonts.googleapis.com and fonts.gstatic.com to CSP style-src and font-src directives