### PR TITLE
feat: initialize Supabase and tighten sharing flows

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -57,6 +57,11 @@ export type UserSearchResult = {
   email: string
 }
 
+export type ShareSearchContext = {
+  entityType: 'plan' | 'template'
+  entityId: string
+}
+
 async function getUserById(userId: string): Promise<Tables<'users'> | null> {
   const { data, error } = await supabase.from('users').select('*').eq('id', userId).maybeSingle()
 
@@ -86,7 +91,10 @@ export async function saveUserPreferences(
   if (error) throw error
 }
 
-export async function searchUsersByEmail(query: string): Promise<UserSearchResult[]> {
+export async function searchUsersByEmail(
+  query: string,
+  context: ShareSearchContext,
+): Promise<UserSearchResult[]> {
   if (!query.trim()) return []
 
   const { data, error } = await (
@@ -94,6 +102,8 @@ export async function searchUsersByEmail(query: string): Promise<UserSearchResul
       rpc: (fn: string, args?: unknown) => Promise<{ data: unknown; error: unknown }>
     }
   ).rpc('search_users_for_sharing', {
+    entity_type: context.entityType,
+    entity_id: context.entityId,
     q: query.trim(),
   })
 

--- a/src/components/shared/ShareEntityDialog.vue
+++ b/src/components/shared/ShareEntityDialog.vue
@@ -61,7 +61,11 @@ const { data: sharedUsersData, isFetching: isLoadingShares } = useSharedUsersQue
   props.entityType,
   reactiveEntityId,
 )
-const { data: searchData, isFetching: isSearching } = useSearchUsersQuery(searchQuery)
+const { data: searchData, isFetching: isSearching } = useSearchUsersQuery(
+  searchQuery,
+  props.entityType,
+  reactiveEntityId,
+)
 const shareMutation = useShareEntityMutation(props.entityType, userId)
 const unshareMutation = useUnshareEntityMutation(props.entityType)
 const updatePermissionMutation = useUpdatePermissionMutation(props.entityType)
@@ -117,12 +121,12 @@ async function handleUpdateUserPermission(
 }
 
 async function handleRemoveUserAccess(entityId: string, targetUserId: string) {
-  await unshareMutation.mutateAsync({ entityId, userId: targetUserId })
   await emitNotificationEvent({
     type: props.entityType === 'plan' ? 'shared_plan_removed' : 'shared_template_removed',
     entityType: props.entityType,
     entityId,
     targetUserId,
   })
+  await unshareMutation.mutateAsync({ entityId, userId: targetUserId })
 }
 </script>

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -617,7 +617,7 @@ export type Database = {
         Returns: boolean
       }
       search_users_for_sharing: {
-        Args: { q: string }
+        Args: { entity_id: string; entity_type: string; q: string }
         Returns: {
           email: string
           id: string

--- a/src/mocks/handlers/edge-functions.ts
+++ b/src/mocks/handlers/edge-functions.ts
@@ -60,18 +60,22 @@ function getRecipients(
   actorId: string,
   ownerId: string,
 ): string[] {
+  const participantIds = dedupe([
+    ownerId,
+    ...getShareRows(input.entityType, input.entityId).map((share) => share.shared_with_user_id),
+  ])
+
   if (input.targetUserIds?.length) {
-    return dedupe(input.targetUserIds).filter((userId) => userId !== actorId)
+    return dedupe(input.targetUserIds).filter(
+      (userId) => userId !== actorId && participantIds.includes(userId),
+    )
   }
 
   if (input.targetUserId) {
-    return input.targetUserId === actorId ? [] : [input.targetUserId]
+    return input.targetUserId !== actorId && participantIds.includes(input.targetUserId)
+      ? [input.targetUserId]
+      : []
   }
-
-  const participantIds = [
-    ownerId,
-    ...getShareRows(input.entityType, input.entityId).map((share) => share.shared_with_user_id),
-  ]
 
   return dedupe(participantIds).filter((userId) => userId !== actorId)
 }

--- a/src/mocks/handlers/rpc.ts
+++ b/src/mocks/handlers/rpc.ts
@@ -78,10 +78,26 @@ export const rpcHandlers = [
 
   // search_users_for_sharing
   http.post(`${SUPABASE_URL}/rest/v1/rpc/search_users_for_sharing`, async ({ request }) => {
-    const body = (await request.json()) as { q: string }
+    const body = (await request.json()) as { q: string; entity_id?: string; entity_type?: string }
     const query = body.q.toLowerCase()
+    const sharedUserIds =
+      body.entity_type === 'plan'
+        ? new Set(
+            getAll('plan_shares')
+              .filter((share) => share.plan_id === body.entity_id)
+              .map((share) => share.shared_with_user_id),
+          )
+        : new Set(
+            getAll('template_shares')
+              .filter((share) => share.template_id === body.entity_id)
+              .map((share) => share.shared_with_user_id),
+          )
     const results = seedUsers
-      .filter((u) => u.email.toLowerCase().includes(query) || u.name.toLowerCase().includes(query))
+      .filter(
+        (u) =>
+          !sharedUserIds.has(u.id) &&
+          (u.email.toLowerCase().includes(query) || u.name.toLowerCase().includes(query)),
+      )
       .map((u) => ({ id: u.id, name: u.name, email: u.email }))
     return HttpResponse.json(results)
   }),

--- a/src/queries/query-keys.ts
+++ b/src/queries/query-keys.ts
@@ -39,6 +39,7 @@ export const queryKeys = {
   },
   users: {
     all: ['users'] as const,
-    search: (query: string) => [...queryKeys.users.all, 'search', query] as const,
+    search: (entityType: 'plan' | 'template', entityId: string, query: string) =>
+      [...queryKeys.users.all, 'search', entityType, entityId, query] as const,
   },
 } as const

--- a/src/queries/sharing.ts
+++ b/src/queries/sharing.ts
@@ -116,11 +116,19 @@ export function useUpdatePermissionMutation(entityType: EntityType) {
   })
 }
 
-export function useSearchUsersQuery(query: MaybeRefOrGetter<string>) {
+export function useSearchUsersQuery(
+  query: MaybeRefOrGetter<string>,
+  entityType: EntityType,
+  entityId: MaybeRefOrGetter<string>,
+) {
   return useQuery({
-    queryKey: computed(() => queryKeys.users.search(toValue(query))),
-    queryFn: () => searchUsersByEmail(toValue(query)),
-    enabled: computed(() => toValue(query).trim().length > 0),
+    queryKey: computed(() => queryKeys.users.search(entityType, toValue(entityId), toValue(query))),
+    queryFn: () =>
+      searchUsersByEmail(toValue(query), {
+        entityType,
+        entityId: toValue(entityId),
+      }),
+    enabled: computed(() => !!toValue(entityId) && toValue(query).trim().length > 0),
     staleTime: 30 * 1000,
     meta: { errorKey: 'USERS.SEARCH_FAILED' as const },
   })

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,17 @@
+# Supabase Setup
+
+Apply the project schema to a fresh Supabase project with the CLI:
+
+```bash
+npx supabase db push
+```
+
+This repo keeps the required database state in `supabase/migrations/`:
+
+- core tables for categories, users, templates, plans, expenses, notifications, and push subscriptions
+- auth-to-`public.users` sync trigger
+- sharing and budget RPC functions used by the app
+- row-level security policies for authenticated access
+- baseline seeded categories
+
+After the database is pushed, deploy the edge functions from `supabase/functions/` and configure the frontend env vars plus any function secrets required for AI, currency, and push features.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -16,6 +16,18 @@ verify_jwt = true
 import_map = "./functions/emit-notification-event/deno.json"
 entrypoint = "./functions/emit-notification-event/index.ts"
 
+[functions.analyze-expense-photo]
+enabled = true
+verify_jwt = true
+import_map = "./functions/analyze-expense-photo/deno.json"
+entrypoint = "./functions/analyze-expense-photo/index.ts"
+
+[functions.convert-currency]
+enabled = true
+verify_jwt = true
+import_map = "./functions/convert-currency/deno.json"
+entrypoint = "./functions/convert-currency/index.ts"
+
 [functions.push-subscriptions]
 enabled = true
 verify_jwt = true

--- a/supabase/functions/emit-notification-event/index.ts
+++ b/supabase/functions/emit-notification-event/index.ts
@@ -204,20 +204,25 @@ async function resolveRecipients(
   actorId: string,
   ownerId: string,
 ): Promise<string[]> {
-  if (input.targetUserIds?.length) {
-    return dedupe(input.targetUserIds).filter((userId) => userId !== actorId)
-  }
-
-  if (input.targetUserId) {
-    return input.targetUserId === actorId ? [] : [input.targetUserId]
-  }
-
   const participants = await getAllParticipants(
     serviceClient,
     input.entityType,
     input.entityId,
     ownerId,
   )
+  const participantSet = new Set(participants)
+
+  if (input.targetUserIds?.length) {
+    return dedupe(input.targetUserIds).filter(
+      (userId) => userId !== actorId && participantSet.has(userId),
+    )
+  }
+
+  if (input.targetUserId) {
+    return input.targetUserId !== actorId && participantSet.has(input.targetUserId)
+      ? [input.targetUserId]
+      : []
+  }
 
   return participants.filter((userId) => userId !== actorId)
 }

--- a/supabase/migrations/20260411110000_init_schema.sql
+++ b/supabase/migrations/20260411110000_init_schema.sql
@@ -1,0 +1,315 @@
+create extension if not exists pgcrypto;
+
+create or replace function public.set_row_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+create table if not exists public.categories (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  icon text not null,
+  color text not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz,
+  constraint categories_name_not_blank check (char_length(trim(name)) > 0),
+  constraint categories_icon_not_blank check (char_length(trim(icon)) > 0),
+  constraint categories_color_hex check (color ~ '^#[0-9A-Fa-f]{6}$')
+);
+
+create unique index if not exists categories_name_key
+  on public.categories (lower(name));
+
+create table if not exists public.users (
+  id uuid primary key,
+  email text not null,
+  name text not null,
+  avatar text,
+  preferences jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz,
+  constraint users_email_not_blank check (char_length(trim(email)) > 0),
+  constraint users_name_not_blank check (char_length(trim(name)) > 0)
+);
+
+create unique index if not exists users_email_lower_key
+  on public.users (lower(email));
+
+create table if not exists public.templates (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  owner_id uuid not null,
+  duration text not null,
+  total numeric(12, 2),
+  currency text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz,
+  constraint templates_name_not_blank check (char_length(trim(name)) > 0),
+  constraint templates_duration_valid check (duration in ('weekly', 'monthly', 'yearly')),
+  constraint templates_total_non_negative check (total is null or total >= 0),
+  constraint templates_currency_valid check (
+    currency is null or currency in ('EUR', 'USD', 'GBP')
+  )
+);
+
+create unique index if not exists unique_template_name_per_user
+  on public.templates (owner_id, lower(name));
+
+create index if not exists templates_owner_created_at_idx
+  on public.templates (owner_id, created_at desc);
+
+create table if not exists public.template_items (
+  id uuid primary key default gen_random_uuid(),
+  template_id uuid not null references public.templates(id) on delete cascade,
+  name text not null,
+  category_id uuid not null references public.categories(id),
+  amount numeric(12, 2) not null,
+  is_fixed_payment boolean not null default false,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz,
+  constraint template_items_name_not_blank check (char_length(trim(name)) > 0),
+  constraint template_items_amount_positive check (amount > 0)
+);
+
+create index if not exists template_items_template_id_idx
+  on public.template_items (template_id, created_at asc);
+
+create index if not exists template_items_category_id_idx
+  on public.template_items (category_id);
+
+create table if not exists public.plans (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  owner_id uuid not null,
+  template_id uuid not null references public.templates(id),
+  start_date date not null,
+  end_date date not null,
+  total numeric(12, 2),
+  currency text,
+  status text not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz,
+  constraint plans_name_not_blank check (char_length(trim(name)) > 0),
+  constraint plans_total_non_negative check (total is null or total >= 0),
+  constraint plans_currency_valid check (
+    currency is null or currency in ('EUR', 'USD', 'GBP')
+  ),
+  constraint plans_status_valid check (
+    status in ('pending', 'active', 'completed', 'cancelled')
+  ),
+  constraint plans_date_range_valid check (start_date <= end_date)
+);
+
+create unique index if not exists unique_plan_name_per_user
+  on public.plans (owner_id, lower(name));
+
+create index if not exists plans_owner_created_at_idx
+  on public.plans (owner_id, created_at desc);
+
+create index if not exists plans_status_idx
+  on public.plans (status);
+
+create table if not exists public.plan_items (
+  id uuid primary key default gen_random_uuid(),
+  plan_id uuid not null references public.plans(id) on delete cascade,
+  name text not null,
+  category_id uuid not null references public.categories(id),
+  amount numeric(12, 2) not null,
+  is_fixed_payment boolean not null default false,
+  is_completed boolean not null default false,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz,
+  constraint plan_items_name_not_blank check (char_length(trim(name)) > 0),
+  constraint plan_items_amount_positive check (amount > 0)
+);
+
+create index if not exists plan_items_plan_id_idx
+  on public.plan_items (plan_id, created_at asc);
+
+create index if not exists plan_items_category_id_idx
+  on public.plan_items (category_id);
+
+create table if not exists public.template_shares (
+  id uuid primary key default gen_random_uuid(),
+  template_id uuid not null references public.templates(id) on delete cascade,
+  shared_by_user_id uuid not null,
+  shared_with_user_id uuid not null,
+  permission_level text not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  constraint template_shares_permission_valid check (permission_level in ('view', 'edit')),
+  constraint template_shares_not_self check (shared_by_user_id <> shared_with_user_id)
+);
+
+create unique index if not exists template_shares_template_user_key
+  on public.template_shares (template_id, shared_with_user_id);
+
+create index if not exists template_shares_shared_with_idx
+  on public.template_shares (shared_with_user_id, created_at desc);
+
+create table if not exists public.plan_shares (
+  id uuid primary key default gen_random_uuid(),
+  plan_id uuid not null references public.plans(id) on delete cascade,
+  shared_by_user_id uuid not null,
+  shared_with_user_id uuid not null,
+  permission_level text not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  constraint plan_shares_permission_valid check (permission_level in ('view', 'edit')),
+  constraint plan_shares_not_self check (shared_by_user_id <> shared_with_user_id)
+);
+
+create unique index if not exists plan_shares_plan_user_key
+  on public.plan_shares (plan_id, shared_with_user_id);
+
+create index if not exists plan_shares_shared_with_idx
+  on public.plan_shares (shared_with_user_id, created_at desc);
+
+create table if not exists public.expenses (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  amount numeric(12, 2) not null,
+  category_id uuid not null references public.categories(id),
+  plan_id uuid not null references public.plans(id) on delete cascade,
+  plan_item_id uuid references public.plan_items(id) on delete set null,
+  user_id uuid not null,
+  expense_date date not null default current_date,
+  currency text,
+  original_amount numeric(12, 2),
+  original_currency text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz,
+  constraint expenses_name_not_blank check (char_length(trim(name)) > 0),
+  constraint expenses_amount_positive check (amount > 0),
+  constraint expenses_original_amount_positive check (
+    original_amount is null or original_amount > 0
+  ),
+  constraint expenses_currency_valid check (
+    currency is null or currency in ('EUR', 'USD', 'GBP')
+  ),
+  constraint expenses_original_currency_valid check (
+    original_currency is null or original_currency in ('EUR', 'USD', 'GBP')
+  )
+);
+
+create index if not exists expenses_plan_id_expense_date_idx
+  on public.expenses (plan_id, expense_date desc, created_at desc);
+
+create index if not exists expenses_plan_item_id_idx
+  on public.expenses (plan_item_id);
+
+create index if not exists expenses_category_id_idx
+  on public.expenses (category_id);
+
+create table if not exists public.notifications (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  actor_user_id uuid references public.users(id) on delete set null,
+  type text not null,
+  title text not null,
+  body text not null,
+  entity_type text not null,
+  entity_id uuid not null,
+  payload jsonb not null default '{}'::jsonb,
+  read_at timestamptz,
+  deleted_at timestamptz,
+  push_attempted_at timestamptz,
+  push_sent_at timestamptz,
+  push_error text,
+  created_at timestamptz not null default timezone('utc', now()),
+  constraint notifications_type_valid check (
+    type in (
+      'plan_shared',
+      'template_shared',
+      'shared_plan_updated',
+      'shared_template_updated',
+      'shared_plan_expense_added',
+      'shared_plan_removed',
+      'shared_template_removed',
+      'shared_plan_cancelled',
+      'shared_plan_permission_changed',
+      'shared_template_permission_changed'
+    )
+  ),
+  constraint notifications_entity_type_valid check (entity_type in ('plan', 'template')),
+  constraint notifications_title_not_blank check (char_length(trim(title)) > 0),
+  constraint notifications_body_not_blank check (char_length(trim(body)) > 0)
+);
+
+create index if not exists notifications_user_created_at_idx
+  on public.notifications (user_id, created_at desc);
+
+create index if not exists notifications_user_unread_idx
+  on public.notifications (user_id, read_at, deleted_at);
+
+create table if not exists public.push_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  endpoint text not null,
+  p256dh text not null,
+  auth text not null,
+  user_agent text,
+  revoked_at timestamptz,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint push_subscriptions_endpoint_not_blank check (char_length(trim(endpoint)) > 0),
+  constraint push_subscriptions_p256dh_not_blank check (char_length(trim(p256dh)) > 0),
+  constraint push_subscriptions_auth_not_blank check (char_length(trim(auth)) > 0)
+);
+
+create unique index if not exists push_subscriptions_endpoint_key
+  on public.push_subscriptions (endpoint);
+
+create index if not exists push_subscriptions_user_revoked_idx
+  on public.push_subscriptions (user_id, revoked_at);
+
+drop trigger if exists categories_set_updated_at on public.categories;
+create trigger categories_set_updated_at
+before update on public.categories
+for each row
+execute function public.set_row_updated_at();
+
+drop trigger if exists users_set_updated_at on public.users;
+create trigger users_set_updated_at
+before update on public.users
+for each row
+execute function public.set_row_updated_at();
+
+drop trigger if exists templates_set_updated_at on public.templates;
+create trigger templates_set_updated_at
+before update on public.templates
+for each row
+execute function public.set_row_updated_at();
+
+drop trigger if exists template_items_set_updated_at on public.template_items;
+create trigger template_items_set_updated_at
+before update on public.template_items
+for each row
+execute function public.set_row_updated_at();
+
+drop trigger if exists plans_set_updated_at on public.plans;
+create trigger plans_set_updated_at
+before update on public.plans
+for each row
+execute function public.set_row_updated_at();
+
+drop trigger if exists plan_items_set_updated_at on public.plan_items;
+create trigger plan_items_set_updated_at
+before update on public.plan_items
+for each row
+execute function public.set_row_updated_at();
+
+drop trigger if exists expenses_set_updated_at on public.expenses;
+create trigger expenses_set_updated_at
+before update on public.expenses
+for each row
+execute function public.set_row_updated_at();
+
+drop trigger if exists push_subscriptions_set_updated_at on public.push_subscriptions;
+create trigger push_subscriptions_set_updated_at
+before update on public.push_subscriptions
+for each row
+execute function public.set_row_updated_at();

--- a/supabase/migrations/20260411110100_init_functions.sql
+++ b/supabase/migrations/20260411110100_init_functions.sql
@@ -1,0 +1,527 @@
+create or replace function public.handle_auth_user_sync()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  resolved_email text;
+  resolved_name text;
+  resolved_avatar text;
+begin
+  resolved_email := coalesce(new.email, concat(new.id::text, '@local.invalid'));
+  resolved_name := coalesce(
+    nullif(trim(new.raw_user_meta_data ->> 'full_name'), ''),
+    nullif(trim(new.raw_user_meta_data ->> 'name'), ''),
+    split_part(resolved_email, '@', 1)
+  );
+  resolved_avatar := coalesce(
+    nullif(trim(new.raw_user_meta_data ->> 'avatar_url'), ''),
+    nullif(trim(new.raw_user_meta_data ->> 'picture'), '')
+  );
+
+  insert into public.users (id, email, name, avatar)
+  values (new.id, resolved_email, resolved_name, resolved_avatar)
+  on conflict (id) do update
+  set email = excluded.email,
+      name = excluded.name,
+      avatar = excluded.avatar,
+      updated_at = timezone('utc', now());
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_sync on auth.users;
+create trigger on_auth_user_sync
+after insert or update of email, raw_user_meta_data on auth.users
+for each row
+execute function public.handle_auth_user_sync();
+
+create or replace function public.calculate_plan_status(
+  p_start_date date,
+  p_end_date date,
+  p_current_status text default null
+)
+returns text
+language sql
+stable
+as $$
+  select case
+    when p_current_status = 'cancelled' then 'cancelled'
+    when current_date < p_start_date then 'pending'
+    when current_date > p_end_date then 'completed'
+    else 'active'
+  end;
+$$;
+
+create or replace function public.can_access_template(
+  template_id uuid,
+  user_id uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.templates t
+    where t.id = template_id
+      and t.owner_id = user_id
+  ) or exists (
+    select 1
+    from public.template_shares ts
+    where ts.template_id = template_id
+      and ts.shared_with_user_id = user_id
+  );
+$$;
+
+create or replace function public.can_edit_template(
+  template_id uuid,
+  user_id uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.templates t
+    where t.id = template_id
+      and t.owner_id = user_id
+  ) or exists (
+    select 1
+    from public.template_shares ts
+    where ts.template_id = template_id
+      and ts.shared_with_user_id = user_id
+      and ts.permission_level = 'edit'
+  );
+$$;
+
+create or replace function public.is_template_owner(
+  template_id uuid,
+  user_id uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.templates t
+    where t.id = template_id
+      and t.owner_id = user_id
+  );
+$$;
+
+create or replace function public.user_has_template_access(
+  template_id uuid,
+  user_id uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.can_access_template(template_id, user_id);
+$$;
+
+create or replace function public.user_owns_plan(
+  plan_id uuid,
+  user_id uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.plans p
+    where p.id = plan_id
+      and p.owner_id = user_id
+  );
+$$;
+
+create or replace function public.can_access_plan(
+  p_plan_id uuid,
+  p_user_id uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.plans p
+    where p.id = p_plan_id
+      and p.owner_id = p_user_id
+  ) or exists (
+    select 1
+    from public.plan_shares ps
+    where ps.plan_id = p_plan_id
+      and ps.shared_with_user_id = p_user_id
+  );
+$$;
+
+create or replace function public.can_edit_plan(
+  p_plan_id uuid,
+  p_user_id uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.plans p
+    where p.id = p_plan_id
+      and p.owner_id = p_user_id
+  ) or exists (
+    select 1
+    from public.plan_shares ps
+    where ps.plan_id = p_plan_id
+      and ps.shared_with_user_id = p_user_id
+      and ps.permission_level = 'edit'
+  );
+$$;
+
+create or replace function public.get_user_accessible_plan_ids(
+  user_id uuid default auth.uid()
+)
+returns table (plan_id uuid)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select p.id
+  from public.plans p
+  where p.owner_id = user_id
+  union
+  select ps.plan_id
+  from public.plan_shares ps
+  where ps.shared_with_user_id = user_id;
+$$;
+
+create or replace function public.get_user_editable_plan_ids(
+  user_id uuid default auth.uid()
+)
+returns table (plan_id uuid)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select p.id
+  from public.plans p
+  where p.owner_id = user_id
+  union
+  select ps.plan_id
+  from public.plan_shares ps
+  where ps.shared_with_user_id = user_id
+    and ps.permission_level = 'edit';
+$$;
+
+create or replace function public.get_template_shared_users(
+  p_template_id uuid
+)
+returns table (
+  user_id uuid,
+  user_name text,
+  user_email text,
+  permission_level text,
+  shared_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    ts.shared_with_user_id as user_id,
+    u.name as user_name,
+    u.email as user_email,
+    ts.permission_level,
+    ts.created_at as shared_at
+  from public.template_shares ts
+  join public.users u on u.id = ts.shared_with_user_id
+  where ts.template_id = p_template_id
+  order by ts.created_at asc, lower(u.email) asc;
+$$;
+
+create or replace function public.get_plan_shared_users(
+  p_plan_id uuid
+)
+returns table (
+  user_id uuid,
+  user_name text,
+  user_email text,
+  permission_level text,
+  shared_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    ps.shared_with_user_id as user_id,
+    u.name as user_name,
+    u.email as user_email,
+    ps.permission_level,
+    ps.created_at as shared_at
+  from public.plan_shares ps
+  join public.users u on u.id = ps.shared_with_user_id
+  where ps.plan_id = p_plan_id
+  order by ps.created_at asc, lower(u.email) asc;
+$$;
+
+create or replace function public.search_users_for_sharing(
+  q text default '',
+  entity_id uuid default null,
+  entity_type text default null
+)
+returns table (
+  id uuid,
+  email text,
+  name text
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with current_user as (
+    select auth.uid() as user_id
+  ),
+  normalized as (
+    select lower(trim(coalesce(q, ''))) as query
+  ),
+  excluded_users as (
+    select t.owner_id as user_id
+    from public.templates t
+    where entity_type = 'template'
+      and entity_id is not null
+      and t.id = entity_id
+    union
+    select ts.shared_with_user_id
+    from public.template_shares ts
+    where entity_type = 'template'
+      and entity_id is not null
+      and ts.template_id = entity_id
+    union
+    select p.owner_id
+    from public.plans p
+    where entity_type = 'plan'
+      and entity_id is not null
+      and p.id = entity_id
+    union
+    select ps.shared_with_user_id
+    from public.plan_shares ps
+    where entity_type = 'plan'
+      and entity_id is not null
+      and ps.plan_id = entity_id
+    union
+    select user_id
+    from current_user
+  )
+  select
+    u.id,
+    u.email,
+    u.name
+  from public.users u
+  cross join normalized n
+  where n.query <> ''
+    and u.id not in (select eu.user_id from excluded_users eu)
+    and (
+      lower(u.email) like '%' || n.query || '%'
+      or lower(u.name) like '%' || n.query || '%'
+    )
+  order by
+    case when lower(u.email) = n.query then 0 else 1 end,
+    case when lower(u.name) = n.query then 0 else 1 end,
+    lower(u.email) asc
+  limit 10;
+$$;
+
+create or replace function public.get_plan_expense_summary(
+  p_plan_id uuid
+)
+returns table (
+  category_id uuid,
+  planned_amount numeric,
+  actual_amount numeric,
+  remaining_amount numeric,
+  expense_count bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with planned as (
+    select
+      pi.category_id,
+      sum(pi.amount)::numeric as planned_amount
+    from public.plan_items pi
+    where pi.plan_id = p_plan_id
+    group by pi.category_id
+  ),
+  spent as (
+    select
+      e.category_id,
+      sum(e.amount)::numeric as actual_amount,
+      count(*)::bigint as expense_count
+    from public.expenses e
+    where e.plan_id = p_plan_id
+    group by e.category_id
+  )
+  select
+    planned.category_id,
+    planned.planned_amount,
+    coalesce(spent.actual_amount, 0)::numeric as actual_amount,
+    (planned.planned_amount - coalesce(spent.actual_amount, 0))::numeric as remaining_amount,
+    coalesce(spent.expense_count, 0)::bigint as expense_count
+  from planned
+  left join spent on spent.category_id = planned.category_id
+  order by planned.category_id;
+$$;
+
+create or replace function public.get_plan_items_with_tracking(
+  p_plan_id uuid
+)
+returns table (
+  id uuid,
+  plan_id uuid,
+  category_id uuid,
+  name text,
+  amount numeric,
+  is_completed boolean,
+  created_at timestamptz,
+  updated_at timestamptz,
+  expense_count bigint,
+  spent_amount numeric,
+  remaining_amount numeric
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    pi.id,
+    pi.plan_id,
+    pi.category_id,
+    pi.name,
+    pi.amount,
+    pi.is_completed,
+    pi.created_at,
+    coalesce(pi.updated_at, pi.created_at) as updated_at,
+    count(e.id)::bigint as expense_count,
+    coalesce(sum(e.amount), 0)::numeric as spent_amount,
+    (pi.amount - coalesce(sum(e.amount), 0))::numeric as remaining_amount
+  from public.plan_items pi
+  left join public.expenses e on e.plan_item_id = pi.id
+  where pi.plan_id = p_plan_id
+  group by pi.id
+  order by pi.created_at asc;
+$$;
+
+create or replace function public.get_plan_items_with_tracking_by_category(
+  p_category_id uuid,
+  p_plan_id uuid
+)
+returns table (
+  id uuid,
+  plan_id uuid,
+  category_id uuid,
+  name text,
+  amount numeric,
+  is_completed boolean,
+  created_at timestamptz,
+  updated_at timestamptz,
+  expense_count bigint,
+  spent_amount numeric,
+  remaining_amount numeric
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select *
+  from public.get_plan_items_with_tracking(p_plan_id)
+  where category_id = p_category_id
+  order by created_at asc;
+$$;
+
+create or replace function public.check_excessive_sharing(
+  user_id uuid default auth.uid(),
+  max_shares integer default 25,
+  hours_window integer default 24
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with recent_shares as (
+    select count(*)::integer as share_count
+    from (
+      select created_at
+      from public.plan_shares
+      where shared_by_user_id = user_id
+        and created_at >= timezone('utc', now()) - make_interval(hours => hours_window)
+      union all
+      select created_at
+      from public.template_shares
+      where shared_by_user_id = user_id
+        and created_at >= timezone('utc', now()) - make_interval(hours => hours_window)
+    ) shares
+  )
+  select coalesce((select share_count from recent_shares), 0) > max_shares;
+$$;
+
+create or replace function public.cleanup_audit_logs(
+  days_to_keep integer default 90
+)
+returns integer
+language sql
+as $$
+  select 0;
+$$;
+
+create or replace function public.get_user_activity_summary(
+  user_id uuid default auth.uid(),
+  days_back integer default 30
+)
+returns table (
+  table_name text,
+  operation text,
+  last_activity timestamptz,
+  count bigint
+)
+language sql
+stable
+as $$
+  select
+    null::text as table_name,
+    null::text as operation,
+    null::timestamptz as last_activity,
+    null::bigint as count
+  where false;
+$$;

--- a/supabase/migrations/20260411110200_init_rls_and_seed.sql
+++ b/supabase/migrations/20260411110200_init_rls_and_seed.sql
@@ -1,0 +1,335 @@
+alter table public.categories enable row level security;
+alter table public.users enable row level security;
+alter table public.templates enable row level security;
+alter table public.template_items enable row level security;
+alter table public.template_shares enable row level security;
+alter table public.plans enable row level security;
+alter table public.plan_items enable row level security;
+alter table public.plan_shares enable row level security;
+alter table public.expenses enable row level security;
+alter table public.notifications enable row level security;
+alter table public.push_subscriptions enable row level security;
+
+create policy "categories_select_authenticated"
+on public.categories
+for select
+to authenticated
+using (true);
+
+create policy "users_select_own"
+on public.users
+for select
+to authenticated
+using (id = auth.uid());
+
+create policy "users_update_own"
+on public.users
+for update
+to authenticated
+using (id = auth.uid())
+with check (id = auth.uid());
+
+create policy "templates_select_accessible"
+on public.templates
+for select
+to authenticated
+using (public.can_access_template(id, auth.uid()));
+
+create policy "templates_insert_owner"
+on public.templates
+for insert
+to authenticated
+with check (owner_id = auth.uid());
+
+create policy "templates_update_editable"
+on public.templates
+for update
+to authenticated
+using (public.can_edit_template(id, auth.uid()))
+with check (public.can_edit_template(id, auth.uid()));
+
+create policy "templates_delete_owner"
+on public.templates
+for delete
+to authenticated
+using (owner_id = auth.uid());
+
+create policy "template_items_select_accessible"
+on public.template_items
+for select
+to authenticated
+using (public.can_access_template(template_id, auth.uid()));
+
+create policy "template_items_insert_editable"
+on public.template_items
+for insert
+to authenticated
+with check (public.can_edit_template(template_id, auth.uid()));
+
+create policy "template_items_update_editable"
+on public.template_items
+for update
+to authenticated
+using (public.can_edit_template(template_id, auth.uid()))
+with check (public.can_edit_template(template_id, auth.uid()));
+
+create policy "template_items_delete_editable"
+on public.template_items
+for delete
+to authenticated
+using (public.can_edit_template(template_id, auth.uid()));
+
+create policy "template_shares_select_participants"
+on public.template_shares
+for select
+to authenticated
+using (
+  shared_with_user_id = auth.uid()
+  or exists (
+    select 1
+    from public.templates t
+    where t.id = template_shares.template_id
+      and t.owner_id = auth.uid()
+  )
+);
+
+create policy "template_shares_insert_owner"
+on public.template_shares
+for insert
+to authenticated
+with check (
+  shared_by_user_id = auth.uid()
+  and exists (
+    select 1
+    from public.templates t
+    where t.id = template_shares.template_id
+      and t.owner_id = auth.uid()
+  )
+);
+
+create policy "template_shares_update_owner"
+on public.template_shares
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.templates t
+    where t.id = template_shares.template_id
+      and t.owner_id = auth.uid()
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.templates t
+    where t.id = template_shares.template_id
+      and t.owner_id = auth.uid()
+  )
+);
+
+create policy "template_shares_delete_owner"
+on public.template_shares
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.templates t
+    where t.id = template_shares.template_id
+      and t.owner_id = auth.uid()
+  )
+);
+
+create policy "plans_select_accessible"
+on public.plans
+for select
+to authenticated
+using (public.can_access_plan(id, auth.uid()));
+
+create policy "plans_insert_owner"
+on public.plans
+for insert
+to authenticated
+with check (owner_id = auth.uid());
+
+create policy "plans_update_editable"
+on public.plans
+for update
+to authenticated
+using (public.can_edit_plan(id, auth.uid()))
+with check (public.can_edit_plan(id, auth.uid()));
+
+create policy "plans_delete_owner"
+on public.plans
+for delete
+to authenticated
+using (owner_id = auth.uid());
+
+create policy "plan_items_select_accessible"
+on public.plan_items
+for select
+to authenticated
+using (public.can_access_plan(plan_id, auth.uid()));
+
+create policy "plan_items_insert_editable"
+on public.plan_items
+for insert
+to authenticated
+with check (public.can_edit_plan(plan_id, auth.uid()));
+
+create policy "plan_items_update_editable"
+on public.plan_items
+for update
+to authenticated
+using (public.can_edit_plan(plan_id, auth.uid()))
+with check (public.can_edit_plan(plan_id, auth.uid()));
+
+create policy "plan_items_delete_editable"
+on public.plan_items
+for delete
+to authenticated
+using (public.can_edit_plan(plan_id, auth.uid()));
+
+create policy "plan_shares_select_participants"
+on public.plan_shares
+for select
+to authenticated
+using (
+  shared_with_user_id = auth.uid()
+  or exists (
+    select 1
+    from public.plans p
+    where p.id = plan_shares.plan_id
+      and p.owner_id = auth.uid()
+  )
+);
+
+create policy "plan_shares_insert_owner"
+on public.plan_shares
+for insert
+to authenticated
+with check (
+  shared_by_user_id = auth.uid()
+  and exists (
+    select 1
+    from public.plans p
+    where p.id = plan_shares.plan_id
+      and p.owner_id = auth.uid()
+  )
+);
+
+create policy "plan_shares_update_owner"
+on public.plan_shares
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.plans p
+    where p.id = plan_shares.plan_id
+      and p.owner_id = auth.uid()
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.plans p
+    where p.id = plan_shares.plan_id
+      and p.owner_id = auth.uid()
+  )
+);
+
+create policy "plan_shares_delete_owner"
+on public.plan_shares
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.plans p
+    where p.id = plan_shares.plan_id
+      and p.owner_id = auth.uid()
+  )
+);
+
+create policy "expenses_select_accessible"
+on public.expenses
+for select
+to authenticated
+using (public.can_access_plan(plan_id, auth.uid()));
+
+create policy "expenses_insert_editable"
+on public.expenses
+for insert
+to authenticated
+with check (
+  public.can_edit_plan(plan_id, auth.uid())
+  and user_id = auth.uid()
+);
+
+create policy "expenses_update_editable"
+on public.expenses
+for update
+to authenticated
+using (public.can_edit_plan(plan_id, auth.uid()))
+with check (public.can_edit_plan(plan_id, auth.uid()));
+
+create policy "expenses_delete_editable"
+on public.expenses
+for delete
+to authenticated
+using (public.can_edit_plan(plan_id, auth.uid()));
+
+create policy "notifications_select_own"
+on public.notifications
+for select
+to authenticated
+using (user_id = auth.uid());
+
+create policy "notifications_update_own"
+on public.notifications
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create policy "push_subscriptions_select_own"
+on public.push_subscriptions
+for select
+to authenticated
+using (user_id = auth.uid());
+
+create policy "push_subscriptions_update_own"
+on public.push_subscriptions
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'notifications'
+  ) then
+    alter publication supabase_realtime add table public.notifications;
+  end if;
+end
+$$;
+
+insert into public.categories (id, name, icon, color)
+values
+  ('00000000-0000-4000-a000-000000000101', 'Food & Groceries', 'eva-shopping-cart-outline', '#4CAF50'),
+  ('00000000-0000-4000-a000-000000000102', 'Transport', 'eva-car-outline', '#2196F3'),
+  ('00000000-0000-4000-a000-000000000103', 'Entertainment', 'eva-film-outline', '#9C27B0'),
+  ('00000000-0000-4000-a000-000000000104', 'Shopping', 'eva-pricetags-outline', '#FF9800'),
+  ('00000000-0000-4000-a000-000000000105', 'Bills & Utilities', 'eva-flash-outline', '#F44336')
+on conflict (id) do update
+set name = excluded.name,
+    icon = excluded.icon,
+    color = excluded.color,
+    updated_at = timezone('utc', now());


### PR DESCRIPTION
Add baseline Supabase schema, functions, RLS policies, and setup docs for local project bootstrap. Pass entity context into share search, exclude already shared users from search results, and restrict notification recipients to current participants.