### PR TITLE
feat: add plan and template export flows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,9 +31,14 @@ version-resolver:
   minor:
     labels:
       - minor
+      - feature
+      - enhancement
   patch:
     labels:
       - patch
+      - fix
+      - bug
+      - bugfix
   default: patch
 
 template: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,83 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Find existing draft release
+        id: existing_draft
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              ...context.repo,
+              per_page: 100,
+            })
+
+            const draftReleases = releases
+              .filter((release) => release.draft)
+              .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))
+
+            const existingDraft = draftReleases[0]
+
+            core.setOutput('release_id', existingDraft ? String(existingDraft.id) : '')
+            core.setOutput(
+              'release_ids',
+              JSON.stringify(draftReleases.map((release) => String(release.id))),
+            )
+
       - name: Update draft release
+        id: release_drafter
         uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reconcile draft release
+        if: steps.release_drafter.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          EXISTING_DRAFT_RELEASE_ID: ${{ steps.existing_draft.outputs.release_id }}
+          EXISTING_DRAFT_RELEASE_IDS: ${{ steps.existing_draft.outputs.release_ids }}
+          GENERATED_RELEASE_ID: ${{ steps.release_drafter.outputs.id }}
+        with:
+          script: |
+            const existingDraftReleaseId = process.env.EXISTING_DRAFT_RELEASE_ID
+            const generatedReleaseId = process.env.GENERATED_RELEASE_ID
+            const existingDraftReleaseIds = JSON.parse(process.env.EXISTING_DRAFT_RELEASE_IDS || '[]')
+
+            if (!generatedReleaseId) {
+              core.setFailed('Release Drafter did not return a release id.')
+              return
+            }
+
+            const generatedRelease = (
+              await github.rest.repos.getRelease({
+                ...context.repo,
+                release_id: Number(generatedReleaseId),
+              })
+            ).data
+
+            let releaseToKeepId = generatedRelease.id
+
+            if (existingDraftReleaseId && existingDraftReleaseId !== generatedReleaseId) {
+              await github.rest.repos.updateRelease({
+                ...context.repo,
+                release_id: Number(existingDraftReleaseId),
+                tag_name: generatedRelease.tag_name,
+                target_commitish: generatedRelease.target_commitish,
+                name: generatedRelease.name,
+                body: generatedRelease.body,
+                draft: true,
+                prerelease: generatedRelease.prerelease,
+              })
+
+              releaseToKeepId = Number(existingDraftReleaseId)
+            }
+
+            const duplicateDraftReleaseIds = [
+              ...new Set([...existingDraftReleaseIds, generatedReleaseId]),
+            ].filter((releaseId) => Number(releaseId) !== releaseToKeepId)
+
+            for (const releaseId of duplicateDraftReleaseIds) {
+              await github.rest.repos.deleteRelease({
+                ...context.repo,
+                release_id: Number(releaseId),
+              })
+            }

--- a/src/components/plans/PlanCard.test.ts
+++ b/src/components/plans/PlanCard.test.ts
@@ -193,6 +193,16 @@ describe('PlanCard', () => {
     expect(wrapper.emitted('share')?.[0]).toEqual([mockPlan.id])
   })
 
+  it('should emit export event when menu emits export', () => {
+    const wrapper = renderPlanCard({
+      plan: mockPlan,
+    })
+
+    wrapper.vm.$emit('export', mockPlan.id)
+    expect(wrapper.emitted('export')).toBeTruthy()
+    expect(wrapper.emitted('export')?.[0]).toEqual([mockPlan.id])
+  })
+
   it('should emit delete event when menu emits delete', () => {
     const wrapper = renderPlanCard({
       plan: mockPlan,
@@ -246,6 +256,18 @@ describe('PlanCard', () => {
     })
 
     expect(wrapper.props('plan')).toEqual(planWithoutPermission)
+  })
+
+  it('should render overflow actions button for view-only shared plan', () => {
+    const wrapper = renderPlanCard(
+      {
+        plan: { ...mockPlan, owner_id: 'different-user', permission_level: 'view' },
+      },
+      { id: 'user-1' },
+    )
+
+    const actionsButton = wrapper.find('button[aria-label="Actions for Test Plan"]')
+    expect(actionsButton.exists()).toBe(true)
   })
 
   it('should handle plan that is not shared', () => {
@@ -392,7 +414,7 @@ describe('PlanCard', () => {
     expect(nonOwnerWrapper.text()).toContain('Test Plan')
   })
 
-  it('should not show PlanCardMenu for non-owner without edit permission', () => {
+  it('should still show PlanCardMenu for non-owner without edit permission', () => {
     const wrapper = renderPlanCard(
       {
         plan: { ...mockPlan, owner_id: 'different-user', permission_level: 'view' },
@@ -401,7 +423,7 @@ describe('PlanCard', () => {
     )
 
     const menu = wrapper.findComponent('.plan-card-menu')
-    expect(menu.exists()).toBe(false)
+    expect(menu.exists()).toBe(true)
   })
 
   it('should display real amount when privacy mode is disabled', () => {

--- a/src/components/plans/PlanCard.vue
+++ b/src/components/plans/PlanCard.vue
@@ -36,7 +36,7 @@
             </q-icon>
             <!-- Menu button -->
             <q-btn
-              v-if="canEdit"
+              v-if="hasMenuActions"
               flat
               round
               size="sm"
@@ -50,6 +50,7 @@
                 :can-edit="canEdit"
                 :permission-level="plan.permission_level"
                 :plan-status="planStatus"
+                @export="emit('export', plan.id)"
                 @share="emit('share', plan.id)"
                 @delete="showDeleteDialog"
                 @cancel="showCancelDialog"
@@ -132,6 +133,7 @@ import type { PlanWithPermission } from 'src/api'
 
 const emit = defineEmits<{
   (e: 'edit', id: string): void
+  (e: 'export', id: string): void
   (e: 'share', id: string): void
   (e: 'delete', plan: PlanWithPermission): void
   (e: 'cancel', plan: PlanWithPermission): void
@@ -157,6 +159,7 @@ const isOwner = computed(() => props.plan.owner_id === userStore.userProfile?.id
 const canEdit = computed(() => isOwner.value || props.plan.permission_level === 'edit')
 const planStatus = computed(() => getPlanStatus(props.plan))
 const isViewOnly = computed(() => props.plan.permission_level === 'view')
+const hasMenuActions = computed(() => true)
 const menuButtonLabel = computed(() => `Actions for ${props.plan.name}`)
 
 function formatAmount(amount: number | null | undefined): string {

--- a/src/components/plans/PlanCardMenu.test.ts
+++ b/src/components/plans/PlanCardMenu.test.ts
@@ -56,46 +56,54 @@ describe('PlanCardMenu', () => {
     const wrapper = renderPlanCardMenu({ canEdit: true, planStatus: 'active' })
     const items = wrapper.findAll('.q-item')
     expect(items.length).toBeGreaterThan(0)
-    await items[0]?.trigger('click')
+    await items[1]?.trigger('click')
     expect(wrapper.emitted('share')).toBeTruthy()
   })
 
-  it('should show share and cancel for owner with active plan', async () => {
+  it('should emit export when export item clicked', async () => {
     const wrapper = renderPlanCardMenu({ canEdit: true, planStatus: 'active' })
     const items = wrapper.findAll('.q-item')
-    expect(items.length).toBe(2)
+    expect(items.length).toBe(3)
     await items[0]?.trigger('click')
-    expect(wrapper.emitted('share')).toBeTruthy()
+    expect(wrapper.emitted('export')).toBeTruthy()
+  })
+
+  it('should show export, share and cancel for owner with active plan', async () => {
+    const wrapper = renderPlanCardMenu({ canEdit: true, planStatus: 'active' })
+    const items = wrapper.findAll('.q-item')
+    expect(items.length).toBe(3)
     await items[1]?.trigger('click')
+    expect(wrapper.emitted('share')).toBeTruthy()
+    await items[2]?.trigger('click')
     expect(wrapper.emitted('cancel')).toBeTruthy()
   })
 
-  it('should show share and delete for owner with pending plan', async () => {
+  it('should show export, share and delete for owner with pending plan', async () => {
     const wrapper = renderPlanCardMenu({ canEdit: true, planStatus: 'pending' })
     const items = wrapper.findAll('.q-item')
-    expect(items.length).toBe(2)
-    await items[0]?.trigger('click')
-    expect(wrapper.emitted('share')).toBeTruthy()
+    expect(items.length).toBe(3)
     await items[1]?.trigger('click')
+    expect(wrapper.emitted('share')).toBeTruthy()
+    await items[2]?.trigger('click')
     expect(wrapper.emitted('delete')).toBeTruthy()
   })
 
-  it('should show no items when canEdit is false', () => {
+  it('should show export only when canEdit is false', () => {
     const wrapper = renderPlanCardMenu({
       canEdit: false,
       permissionLevel: 'view',
       planStatus: 'completed',
     })
-    expect(wrapper.findAll('.q-item').length).toBe(0)
+    expect(wrapper.findAll('.q-item').length).toBe(1)
   })
 
   it('should allow delete when plan is cancelled', async () => {
     const wrapper = renderPlanCardMenu({ canEdit: true, planStatus: 'cancelled' })
     const items = wrapper.findAll('.q-item')
-    expect(items.length).toBe(2)
-    await items[0]?.trigger('click')
-    expect(wrapper.emitted('share')).toBeTruthy()
+    expect(items.length).toBe(3)
     await items[1]?.trigger('click')
+    expect(wrapper.emitted('share')).toBeTruthy()
+    await items[2]?.trigger('click')
     expect(wrapper.emitted('delete')).toBeTruthy()
   })
 })

--- a/src/components/plans/PlanCardMenu.vue
+++ b/src/components/plans/PlanCardMenu.vue
@@ -7,12 +7,29 @@
   >
     <q-list dense>
       <q-item
+        clickable
+        @click="emit('export')"
+      >
+        <q-item-section
+          class="min-w-auto q-pr-sm"
+          side
+        >
+          <q-icon
+            name="eva-download-outline"
+            size="xs"
+          />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>Export Plan</q-item-label>
+        </q-item-section>
+      </q-item>
+      <q-item
         v-if="canEdit"
         clickable
         @click="emit('share')"
       >
         <q-item-section
-          class="q-pr-sm"
+          class="min-w-auto q-pr-sm"
           side
         >
           <q-icon
@@ -31,7 +48,7 @@
         @click="emit('cancel')"
       >
         <q-item-section
-          class="q-pr-sm"
+          class="min-w-auto q-pr-sm"
           side
         >
           <q-icon
@@ -51,7 +68,7 @@
         @click="emit('delete')"
       >
         <q-item-section
-          class="q-pr-sm"
+          class="min-w-auto q-pr-sm"
           side
         >
           <q-icon
@@ -72,6 +89,7 @@
 import { computed } from 'vue'
 
 const emit = defineEmits<{
+  (e: 'export'): void
   (e: 'share'): void
   (e: 'delete'): void
   (e: 'cancel'): void
@@ -91,9 +109,8 @@ const canCancel = computed(() => {
   return props.planStatus === 'active'
 })
 
-// Menu should be visible if the user can edit (owner or edit permission)
 const hasActions = computed(() => {
-  return props.canEdit
+  return true
 })
 
 defineExpose({

--- a/src/components/plans/PlansGroup.vue
+++ b/src/components/plans/PlansGroup.vue
@@ -10,6 +10,7 @@
         :plan="item"
         :hide-shared-badge="hideSharedBadge || false"
         @edit="emit('edit', $event)"
+        @export="emit('export', $event)"
         @delete="emit('delete', $event)"
         @share="emit('share', $event)"
         @cancel="emit('cancel', $event)"
@@ -25,6 +26,7 @@ import type { PlanWithPermission } from 'src/api'
 
 const emit = defineEmits<{
   (e: 'edit', id: string): void
+  (e: 'export', id: string): void
   (e: 'share', id: string): void
   (e: 'delete', plan: PlanWithPermission): void
   (e: 'cancel', plan: PlanWithPermission): void

--- a/src/components/shared/ExportDialog.vue
+++ b/src/components/shared/ExportDialog.vue
@@ -1,0 +1,63 @@
+<template>
+  <AppDialogShell
+    :model-value="modelValue"
+    title="Export"
+    body-class="q-pa-sm"
+    :body-scrollable="false"
+    @update:model-value="emit('update:modelValue', $event)"
+  >
+    <q-list>
+      <q-item
+        clickable
+        @click="emit('select-format', 'json')"
+      >
+        <q-item-section
+          avatar
+          class="min-w-auto"
+        >
+          <q-icon
+            name="eva-code-outline"
+            color="primary"
+          />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>JSON</q-item-label>
+          <q-item-label caption>Structured export with full details</q-item-label>
+        </q-item-section>
+      </q-item>
+
+      <q-item
+        clickable
+        @click="emit('select-format', 'csv')"
+      >
+        <q-item-section
+          avatar
+          class="min-w-auto"
+        >
+          <q-icon
+            name="eva-grid-outline"
+            color="primary"
+          />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>CSV</q-item-label>
+          <q-item-label caption>Spreadsheet-friendly item export</q-item-label>
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </AppDialogShell>
+</template>
+
+<script setup lang="ts">
+import AppDialogShell from './AppDialogShell.vue'
+import type { ExportFormat } from 'src/utils/export'
+
+defineProps<{
+  modelValue: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  'select-format': [format: ExportFormat]
+}>()
+</script>

--- a/src/components/templates/TemplateCard.test.ts
+++ b/src/components/templates/TemplateCard.test.ts
@@ -113,6 +113,16 @@ describe('TemplateCard', () => {
     expect(wrapper.emitted('share')?.[0]).toEqual([mockTemplate.id])
   })
 
+  it('should emit export event when menu emits export', () => {
+    const wrapper = renderTemplateCard({
+      template: mockTemplate,
+    })
+
+    wrapper.vm.$emit('export', mockTemplate.id)
+    expect(wrapper.emitted('export')).toBeTruthy()
+    expect(wrapper.emitted('export')?.[0]).toEqual([mockTemplate.id])
+  })
+
   it('should emit delete event when menu emits delete', () => {
     const wrapper = renderTemplateCard({
       template: mockTemplate,
@@ -204,5 +214,13 @@ describe('TemplateCard', () => {
 
     expect(vi.mocked(currencyUtils.formatCurrencyPrivate)).toHaveBeenCalled()
     expect(vi.mocked(currencyUtils.formatCurrency)).not.toHaveBeenCalled()
+  })
+
+  it('shows actions button for view-only shared template', () => {
+    const wrapper = renderTemplateCard({
+      template: { ...mockTemplate, owner_id: 'user-2', permission_level: 'view' },
+    })
+
+    expect(wrapper.find('.q-btn').exists()).toBe(true)
   })
 })

--- a/src/components/templates/TemplateCard.vue
+++ b/src/components/templates/TemplateCard.vue
@@ -41,7 +41,7 @@
             </q-icon>
             <!-- Menu button -->
             <q-btn
-              v-if="canEdit"
+              v-if="hasMenuActions"
               flat
               round
               size="sm"
@@ -52,6 +52,7 @@
               <TemplateCardMenu
                 :can-edit="canEdit"
                 :permission-level="template.permission_level"
+                @export="emit('export', template.id)"
                 @share="emit('share', template.id)"
                 @delete="showDeleteDialog"
               />
@@ -116,6 +117,7 @@ import type { TemplateWithPermission } from 'src/api'
 
 const emit = defineEmits<{
   (e: 'edit', id: string): void
+  (e: 'export', id: string): void
   (e: 'share', id: string): void
   (e: 'delete', template: TemplateWithPermission): void
 }>()
@@ -140,6 +142,7 @@ const isDeleteDialogOpen = ref(false)
 const isOwner = computed(() => props.template.owner_id === userStore.userProfile?.id)
 const canEdit = computed(() => isOwner.value || props.template.permission_level === 'edit')
 const isViewOnly = computed(() => props.template.permission_level === 'view')
+const hasMenuActions = computed(() => true)
 
 function formatAmount(amount: number | null | undefined): string {
   const currency = props.template.currency as CurrencyCode

--- a/src/components/templates/TemplateCardMenu.test.ts
+++ b/src/components/templates/TemplateCardMenu.test.ts
@@ -51,8 +51,19 @@ describe('TemplateCardMenu', () => {
 
     const items = wrapper.findAll('.q-item')
     expect(items.length).toBeGreaterThan(0)
-    await items[0]?.trigger('click')
+    await items[1]?.trigger('click')
     expect(wrapper.emitted('share')).toBeTruthy()
+  })
+
+  it('should emit export event when export item is clicked', async () => {
+    const wrapper = renderTemplateCardMenu({
+      canEdit: true,
+    })
+
+    const items = wrapper.findAll('.q-item')
+    expect(items.length).toBeGreaterThan(0)
+    await items[0]?.trigger('click')
+    expect(wrapper.emitted('export')).toBeTruthy()
   })
 
   it('should emit delete event when delete item is clicked', async () => {
@@ -62,7 +73,7 @@ describe('TemplateCardMenu', () => {
 
     const items = wrapper.findAll('.q-item')
     expect(items.length).toBeGreaterThan(1)
-    await items[1]?.trigger('click')
+    await items[2]?.trigger('click')
     expect(wrapper.emitted('delete')).toBeTruthy()
   })
 
@@ -105,5 +116,13 @@ describe('TemplateCardMenu', () => {
       canEdit: false,
     })
     expect(wrapper.props('permissionLevel')).toBeUndefined()
+  })
+
+  it('shows export item even when canEdit is false', () => {
+    const wrapper = renderTemplateCardMenu({
+      canEdit: false,
+    })
+
+    expect(wrapper.findAll('.q-item').length).toBe(1)
   })
 })

--- a/src/components/templates/TemplateCardMenu.vue
+++ b/src/components/templates/TemplateCardMenu.vue
@@ -7,12 +7,29 @@
   >
     <q-list dense>
       <q-item
+        clickable
+        @click="emit('export')"
+      >
+        <q-item-section
+          class="min-w-auto q-pr-sm"
+          side
+        >
+          <q-icon
+            name="eva-download-outline"
+            size="xs"
+          />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>Export Template</q-item-label>
+        </q-item-section>
+      </q-item>
+      <q-item
         v-if="canEdit"
         clickable
         @click="emit('share')"
       >
         <q-item-section
-          class="q-pr-sm"
+          class="min-w-auto q-pr-sm"
           side
         >
           <q-icon
@@ -31,7 +48,7 @@
         @click="emit('delete')"
       >
         <q-item-section
-          class="q-pr-sm"
+          class="min-w-auto q-pr-sm"
           side
         >
           <q-icon
@@ -51,18 +68,18 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 const emit = defineEmits<{
+  (e: 'export'): void
   (e: 'share'): void
   (e: 'delete'): void
 }>()
 
-const props = defineProps<{
+defineProps<{
   canEdit: boolean
   permissionLevel?: string | undefined
 }>()
 
-// Menu should be visible if the user can edit (owner or edit permission)
 const hasActions = computed(() => {
-  return props.canEdit
+  return true
 })
 
 defineExpose({

--- a/src/components/templates/TemplatesGroup.vue
+++ b/src/components/templates/TemplatesGroup.vue
@@ -10,6 +10,7 @@
         :template="item"
         :hide-shared-badge="hideSharedBadge || false"
         @edit="emit('edit', $event)"
+        @export="emit('export', $event)"
         @delete="emit('delete', $event)"
         @share="emit('share', $event)"
       />
@@ -24,6 +25,7 @@ import type { TemplateWithPermission } from 'src/api'
 
 const emit = defineEmits<{
   (e: 'edit', id: string): void
+  (e: 'export', id: string): void
   (e: 'share', id: string): void
   (e: 'delete', template: TemplateWithPermission): void
 }>()

--- a/src/composables/usePlanActions.test.ts
+++ b/src/composables/usePlanActions.test.ts
@@ -56,6 +56,7 @@ describe('usePlanActions', () => {
       onShare: vi.fn(),
       onCancel: vi.fn(),
       onDelete: vi.fn(),
+      onExport: vi.fn(),
       onAddExpense: vi.fn(),
       onSwitchToEdit: vi.fn(),
     },
@@ -109,6 +110,17 @@ describe('usePlanActions', () => {
 
       const shareAction = actionBarActions.value.find((a) => a.key === 'share')
       expect(shareAction?.visible).toBe(true)
+    })
+
+    it('shows Export button for existing plan', () => {
+      const context = createContext({
+        isNewPlan: ref(false),
+        currentPlan: ref(createMockPlan('active')),
+      })
+      const { actionBarActions } = usePlanActions(context)
+
+      const exportAction = actionBarActions.value.find((a) => a.key === 'export')
+      expect(exportAction?.visible).toBe(true)
     })
 
     it('hides Share button when user cannot edit', () => {
@@ -233,6 +245,18 @@ describe('usePlanActions', () => {
       const shareAction = actionBarActions.value.find((a) => a.key === 'share')
       expect(shareAction?.visible).toBe(true)
     })
+
+    it('shows Export button in read-only overview mode', () => {
+      const context = createContext({
+        currentTab: ref('overview'),
+        isEditMode: ref(false),
+        isNewPlan: ref(false),
+      })
+      const { actionBarActions } = usePlanActions(context)
+
+      const exportAction = actionBarActions.value.find((a) => a.key === 'export')
+      expect(exportAction?.visible).toBe(true)
+    })
   })
 
   describe('items tab actions', () => {
@@ -303,6 +327,7 @@ describe('usePlanActions', () => {
         onShare: vi.fn(),
         onCancel: vi.fn(),
         onDelete: vi.fn(),
+        onExport: vi.fn(),
         onAddExpense: vi.fn(),
         onSwitchToEdit: vi.fn(),
       }
@@ -313,6 +338,28 @@ describe('usePlanActions', () => {
       saveAction?.handler()
 
       expect(handlers.onSave).toHaveBeenCalled()
+    })
+
+    it('calls export handler when export action is triggered', () => {
+      const handlers = {
+        onSave: vi.fn(),
+        onShare: vi.fn(),
+        onCancel: vi.fn(),
+        onDelete: vi.fn(),
+        onExport: vi.fn(),
+        onAddExpense: vi.fn(),
+        onSwitchToEdit: vi.fn(),
+      }
+      const context = createContext({
+        currentTab: ref('overview'),
+        handlers,
+      })
+      const { actionBarActions } = usePlanActions(context)
+
+      const exportAction = actionBarActions.value.find((a) => a.key === 'export')
+      exportAction?.handler()
+
+      expect(handlers.onExport).toHaveBeenCalled()
     })
   })
 })

--- a/src/composables/usePlanActions.ts
+++ b/src/composables/usePlanActions.ts
@@ -10,6 +10,7 @@ export type PlanActionHandlers = {
   onShare: () => void
   onCancel: () => void
   onDelete: () => void
+  onExport: () => void
   onAddExpense: () => void
   onSwitchToEdit: () => void
 }
@@ -52,6 +53,15 @@ export function usePlanActions(context: PlanActionsContext) {
   )
 
   const sharedSecondaryActions = computed<ActionBarAction[]>(() => [
+    {
+      key: 'export',
+      icon: 'eva-download-outline',
+      label: 'Export',
+      color: 'info',
+      priority: 'secondary',
+      visible: !context.isNewPlan.value && !!context.currentPlan.value,
+      handler: context.handlers.onExport,
+    },
     {
       key: 'share',
       icon: 'eva-share-outline',

--- a/src/composables/usePlanExport.ts
+++ b/src/composables/usePlanExport.ts
@@ -1,0 +1,45 @@
+import { toValue, type MaybeRefOrGetter } from 'vue'
+import { useBanner } from 'src/composables/useBanner'
+import type { Category, ExpenseWithCategory, PlanWithItems } from 'src/api'
+import type { CategoryBudget } from 'src/types'
+import { createPlanExportDownload, downloadExportFile, type ExportFormat } from 'src/utils/export'
+
+export function usePlanExport(
+  plan: MaybeRefOrGetter<PlanWithItems | null>,
+  categories: MaybeRefOrGetter<Category[]>,
+  categoryBudgets: MaybeRefOrGetter<CategoryBudget[]>,
+  expenses: MaybeRefOrGetter<ExpenseWithCategory[]>,
+) {
+  const { showError, showSuccess } = useBanner()
+
+  function exportPlan(format: ExportFormat): boolean {
+    const currentPlan = toValue(plan)
+
+    if (!currentPlan) {
+      showError('Plan export is unavailable right now.')
+      return false
+    }
+
+    try {
+      const download = createPlanExportDownload(
+        currentPlan,
+        toValue(categories),
+        toValue(categoryBudgets),
+        toValue(expenses),
+        format,
+      )
+
+      downloadExportFile(download)
+      showSuccess(`Plan exported as ${format.toUpperCase()}.`)
+
+      return true
+    } catch {
+      showError(`Failed to export plan as ${format.toUpperCase()}.`)
+      return false
+    }
+  }
+
+  return {
+    exportPlan,
+  }
+}

--- a/src/composables/usePlanPageState.ts
+++ b/src/composables/usePlanPageState.ts
@@ -12,6 +12,8 @@ import { useEditablePage } from 'src/composables/useEditablePage'
 import { useCategoryRefs } from 'src/composables/useCategoryRefs'
 import { usePlanActions, type PlanSaveState } from 'src/composables/usePlanActions'
 import { validateItemForm } from 'src/composables/useItemFormValidation'
+import { usePlanOverview } from 'src/composables/usePlanOverview'
+import { usePlanExport } from 'src/composables/usePlanExport'
 import { calculateEndDate } from 'src/utils/plans'
 import { formatDateInput } from 'src/utils/date'
 import {
@@ -22,6 +24,7 @@ import {
 } from 'src/api'
 import type { PlanItemUI } from 'src/types'
 import { useNotificationEvents } from 'src/composables/useNotificationEvents'
+import type { ExportFormat } from 'src/utils/export'
 
 const SAVE_SUCCESS_RESET_MS = 4000
 
@@ -77,6 +80,16 @@ export function usePlanPageState() {
   )
 
   const { openDialog, closeDialog, getDialogState } = useEditablePage()
+  const { categoryBudgets, sortedExpenses } = usePlanOverview(
+    computed(() => currentPlan.value?.id ?? null),
+    computed(() => currentPlan.value),
+  )
+  const { exportPlan } = usePlanExport(
+    computed(() => currentPlan.value),
+    categories,
+    categoryBudgets,
+    sortedExpenses,
+  )
 
   const { lastAddedCategoryId, setCategoryRef, scrollToFirstInvalidField, resetLastAddedCategory } =
     useCategoryRefs(planItems)
@@ -126,6 +139,11 @@ export function usePlanPageState() {
     set: (value: boolean) => (value ? openDialog('share') : closeDialog('share')),
   })
 
+  const isExportDialogOpen = computed({
+    get: () => getDialogState('export'),
+    set: (value: boolean) => (value ? openDialog('export') : closeDialog('export')),
+  })
+
   const { actionBarActions, actionsVisible } = usePlanActions({
     isNewPlan,
     isOwner,
@@ -145,6 +163,7 @@ export function usePlanPageState() {
       onDelete: () => {
         showDeleteDialog.value = true
       },
+      onExport: () => openDialog('export'),
       onAddExpense: openExpenseRegistration,
       onSwitchToEdit: () => {
         activeTab.value = 'edit'
@@ -307,6 +326,14 @@ export function usePlanPageState() {
     templateErrorMessage.value = ''
   }
 
+  function handlePlanExport(format: ExportFormat): void {
+    const didExport = exportPlan(format)
+
+    if (didExport) {
+      closeDialog('export')
+    }
+  }
+
   function clearSaveFeedback(): void {
     if (saveState.value !== 'saved') {
       return
@@ -417,6 +444,7 @@ export function usePlanPageState() {
     lastAddedCategoryId,
     setCategoryRef,
     isShareDialogOpen,
+    isExportDialogOpen,
     showCancelDialog,
     showDeleteDialog,
     deletePlanMutation,
@@ -426,6 +454,7 @@ export function usePlanPageState() {
     saveState,
     handleSavePlan,
     onTemplateSelected,
+    handlePlanExport,
     toggleAllCategories,
     handleUpdateItem,
     handleRemoveItem,

--- a/src/composables/useTemplateActions.ts
+++ b/src/composables/useTemplateActions.ts
@@ -1,0 +1,75 @@
+import { computed, type ComputedRef, type Ref } from 'vue'
+import type { ActionBarAction } from 'src/components/shared/ActionBar.vue'
+
+export type TemplateActionHandlers = {
+  onAddCategory: () => void
+  onSave: () => void
+  onShare: () => void
+  onDelete: () => void
+  onExport: () => void
+}
+
+export type TemplateActionsContext = {
+  isNewTemplate: Ref<boolean> | ComputedRef<boolean>
+  isEditMode: Ref<boolean> | ComputedRef<boolean>
+  handlers: TemplateActionHandlers
+}
+
+export function useTemplateActions(context: TemplateActionsContext) {
+  const actionBarActions = computed<ActionBarAction[]>(() => [
+    {
+      key: 'add-category',
+      icon: 'eva-plus-outline',
+      label: 'Category',
+      color: 'primary',
+      priority: 'primary',
+      visible: context.isEditMode.value,
+      handler: context.handlers.onAddCategory,
+    },
+    {
+      key: 'save',
+      icon: 'eva-save-outline',
+      label: context.isNewTemplate.value ? 'Create' : 'Save',
+      color: context.isNewTemplate.value ? 'primary' : 'positive',
+      priority: 'primary',
+      visible: context.isEditMode.value,
+      handler: context.handlers.onSave,
+    },
+    {
+      key: 'export',
+      icon: 'eva-download-outline',
+      label: 'Export',
+      color: 'info',
+      priority: 'secondary',
+      visible: !context.isNewTemplate.value,
+      handler: context.handlers.onExport,
+    },
+    {
+      key: 'share',
+      icon: 'eva-share-outline',
+      label: 'Share',
+      color: 'info',
+      priority: 'secondary',
+      visible: !context.isNewTemplate.value && context.isEditMode.value,
+      handler: context.handlers.onShare,
+    },
+    {
+      key: 'delete',
+      icon: 'eva-trash-2-outline',
+      label: 'Delete',
+      color: 'negative',
+      priority: 'secondary',
+      visible: !context.isNewTemplate.value && context.isEditMode.value,
+      handler: context.handlers.onDelete,
+    },
+  ])
+
+  const actionsVisible = computed(() => {
+    return actionBarActions.value.some((action) => action.visible !== false)
+  })
+
+  return {
+    actionBarActions,
+    actionsVisible,
+  }
+}

--- a/src/composables/useTemplateExport.ts
+++ b/src/composables/useTemplateExport.ts
@@ -1,0 +1,40 @@
+import { toValue, type MaybeRefOrGetter } from 'vue'
+import { useBanner } from 'src/composables/useBanner'
+import type { Category, TemplateWithItems } from 'src/api'
+import {
+  createTemplateExportDownload,
+  downloadExportFile,
+  type ExportFormat,
+} from 'src/utils/export'
+
+export function useTemplateExport(
+  template: MaybeRefOrGetter<TemplateWithItems | null>,
+  categories: MaybeRefOrGetter<Category[]>,
+) {
+  const { showError, showSuccess } = useBanner()
+
+  function exportTemplate(format: ExportFormat): boolean {
+    const currentTemplate = toValue(template)
+
+    if (!currentTemplate) {
+      showError('Template export is unavailable right now.')
+      return false
+    }
+
+    try {
+      const download = createTemplateExportDownload(currentTemplate, toValue(categories), format)
+
+      downloadExportFile(download)
+      showSuccess(`Template exported as ${format.toUpperCase()}.`)
+
+      return true
+    } catch {
+      showError(`Failed to export template as ${format.toUpperCase()}.`)
+      return false
+    }
+  }
+
+  return {
+    exportTemplate,
+  }
+}

--- a/src/composables/useTemplatePageState.ts
+++ b/src/composables/useTemplatePageState.ts
@@ -9,9 +9,11 @@ import { useDetailPageState } from 'src/composables/useDetailPageState'
 import { useEditablePage } from 'src/composables/useEditablePage'
 import { useCategoryRefs } from 'src/composables/useCategoryRefs'
 import { validateItemForm } from 'src/composables/useItemFormValidation'
-import type { ActionBarAction } from 'src/components/shared/ActionBar.vue'
+import { useTemplateActions } from 'src/composables/useTemplateActions'
+import { useTemplateExport } from 'src/composables/useTemplateExport'
 import { getTemplateSharedUsers, type Category, type CurrencyCode } from 'src/api'
 import { useNotificationEvents } from 'src/composables/useNotificationEvents'
+import type { ExportFormat } from 'src/utils/export'
 
 export function useTemplatePageState() {
   const router = useRouter()
@@ -60,6 +62,7 @@ export function useTemplatePageState() {
   )
 
   const { openDialog, closeDialog, getDialogState } = useEditablePage()
+  const { exportTemplate } = useTemplateExport(currentTemplate, categories)
 
   const {
     lastAddedCategoryId,
@@ -91,46 +94,26 @@ export function useTemplatePageState() {
     set: (value: boolean) => (value ? openDialog('share') : closeDialog('share')),
   })
 
-  const actionBarActions = computed<ActionBarAction[]>(() => [
-    {
-      key: 'add-category',
-      icon: 'eva-plus-outline',
-      label: 'Category',
-      color: 'primary',
-      priority: 'primary',
-      visible: isEditMode.value,
-      handler: () => openDialog('category'),
-    },
-    {
-      key: 'save',
-      icon: 'eva-save-outline',
-      label: isNewTemplate.value ? 'Create' : 'Save',
-      color: isNewTemplate.value ? 'primary' : 'positive',
-      priority: 'primary',
-      visible: isEditMode.value,
-      handler: saveTemplate,
-    },
-    {
-      key: 'share',
-      icon: 'eva-share-outline',
-      label: 'Share',
-      color: 'info',
-      priority: 'secondary',
-      visible: !isNewTemplate.value && isEditMode.value,
-      handler: () => openDialog('share'),
-    },
-    {
-      key: 'delete',
-      icon: 'eva-trash-2-outline',
-      label: 'Delete',
-      color: 'negative',
-      priority: 'secondary',
-      visible: !isNewTemplate.value && isEditMode.value,
-      handler: () => {
+  const isExportDialogOpen = computed({
+    get: () => getDialogState('export'),
+    set: (value: boolean) => (value ? openDialog('export') : closeDialog('export')),
+  })
+
+  const { actionBarActions, actionsVisible } = useTemplateActions({
+    isNewTemplate,
+    isEditMode,
+    handlers: {
+      onAddCategory: () => openDialog('category'),
+      onSave: () => {
+        void saveTemplate()
+      },
+      onShare: () => openDialog('share'),
+      onDelete: () => {
         showDeleteDialog.value = true
       },
+      onExport: () => openDialog('export'),
     },
-  ])
+  })
 
   async function handleAddTemplateItem(categoryId: string, categoryColor: string): Promise<void> {
     addTemplateItem(categoryId, categoryColor)
@@ -166,6 +149,14 @@ export function useTemplatePageState() {
   function clearNameError(): void {
     nameError.value = false
     nameErrorMessage.value = ''
+  }
+
+  function handleTemplateExport(format: ExportFormat): void {
+    const didExport = exportTemplate(format)
+
+    if (didExport) {
+      closeDialog('export')
+    }
   }
 
   async function saveTemplate(): Promise<void> {
@@ -275,8 +266,10 @@ export function useTemplatePageState() {
     form,
     allCategoriesExpanded,
     actionBarActions,
+    actionsVisible,
     showCategoryDialog,
     isShareDialogOpen,
+    isExportDialogOpen,
     showDeleteDialog,
     deleteTemplateMutation,
     getUsedCategoryIds,
@@ -287,6 +280,7 @@ export function useTemplatePageState() {
     clearNameError,
     onCategorySelected,
     openCategoryDialog,
+    handleTemplateExport,
     toggleAllCategories,
     goBack,
     onTemplateShared,

--- a/src/pages/PlanPage.test.ts
+++ b/src/pages/PlanPage.test.ts
@@ -420,6 +420,11 @@ function createWrapper(
       stubs: {
         PlanCategory: PlanCategoryStub,
         SharePlanDialog: SharePlanDialogStub,
+        ExportDialog: {
+          template: '<div class="export-dialog-mock" :data-model-value="modelValue"></div>',
+          props: ['modelValue'],
+          emits: ['update:modelValue', 'select-format'],
+        },
         QForm: {
           template: '<form @submit.prevent="handleSubmit"><slot /></form>',
           emits: ['submit'],
@@ -662,6 +667,29 @@ describe('PlanPage', () => {
     await shareButton.trigger('click')
 
     expect(mockUseEditablePage.openDialog).toHaveBeenCalledWith('share')
+  })
+
+  it('should show export button for existing plan in read-only mode', () => {
+    const { wrapper } = createWrapper({ isReadOnlyMode: true, currentPlan: mockPlan })
+
+    const exportButton = wrapper.find('[data-label="Export"]')
+    expect(exportButton.exists()).toBe(true)
+  })
+
+  it('should not show export button for new plan', () => {
+    const { wrapper } = createWrapper({ isNewPlan: true })
+
+    const exportButton = wrapper.find('[data-label="Export"]')
+    expect(exportButton.exists()).toBe(false)
+  })
+
+  it('should open export dialog when export button is clicked', async () => {
+    const { wrapper } = createWrapper({ currentPlan: mockPlan })
+
+    const exportButton = wrapper.find('[data-label="Export"]')
+    await exportButton.trigger('click')
+
+    expect(mockUseEditablePage.openDialog).toHaveBeenCalledWith('export')
   })
 
   it('should display formatted total amount when items exist', () => {

--- a/src/pages/PlanPage.vue
+++ b/src/pages/PlanPage.vue
@@ -139,6 +139,11 @@
         @shared="onPlanShared"
       />
 
+      <ExportDialog
+        v-model="isExportDialogOpen"
+        @select-format="handlePlanExport"
+      />
+
       <DeleteDialog
         v-model="showCancelDialog"
         title="Cancel Plan"
@@ -182,6 +187,7 @@ import PlanOverviewTab from 'src/components/plans/PlanOverviewTab.vue'
 import PlanItemsTrackingTab from 'src/components/plans/PlanItemsTrackingTab.vue'
 import SharePlanDialog from 'src/components/plans/SharePlanDialog.vue'
 import DeleteDialog from 'src/components/shared/DeleteDialog.vue'
+import ExportDialog from 'src/components/shared/ExportDialog.vue'
 import ExpenseRegistrationDialog from 'src/components/expenses/ExpenseRegistrationDialog.vue'
 import { usePlanPageState } from 'src/composables/usePlanPageState'
 
@@ -215,6 +221,7 @@ const {
   lastAddedCategoryId,
   setCategoryRef,
   isShareDialogOpen,
+  isExportDialogOpen,
   showCancelDialog,
   showDeleteDialog,
   deletePlanMutation,
@@ -223,6 +230,7 @@ const {
   selectedCategory,
   handleSavePlan,
   onTemplateSelected,
+  handlePlanExport,
   toggleAllCategories,
   handleUpdateItem,
   handleRemoveItem,

--- a/src/pages/PlansPage.test.ts
+++ b/src/pages/PlansPage.test.ts
@@ -5,6 +5,48 @@ import { ref, computed } from 'vue'
 import PlansPage from './PlansPage.vue'
 import { usePlans } from 'src/composables/usePlans'
 import type { PlanWithPermission } from 'src/api'
+import { getExpensesByPlan, getPlanExpenseSummary, getPlanWithItems } from 'src/api'
+
+vi.mock('src/api', async () => {
+  const actual = await vi.importActual('src/api')
+  return {
+    ...actual,
+    getPlanWithItems: vi.fn(),
+    getExpensesByPlan: vi.fn(),
+    getPlanExpenseSummary: vi.fn(),
+  }
+})
+
+vi.mock('src/queries/categories', () => ({
+  useCategoriesQuery: vi.fn(() => ({
+    categories: ref([
+      {
+        id: 'cat-1',
+        name: 'Food',
+        color: '#FF5722',
+        icon: 'eva-pricetags-outline',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+      },
+    ]),
+  })),
+}))
+
+vi.mock('src/stores/user', () => ({
+  useUserStore: vi.fn(() => ({
+    userProfile: { id: 'user-1' },
+  })),
+}))
+
+const mockShowError = vi.fn()
+const mockShowSuccess = vi.fn()
+
+vi.mock('src/composables/useBanner', () => ({
+  useBanner: vi.fn(() => ({
+    showError: mockShowError,
+    showSuccess: mockShowSuccess,
+  })),
+}))
 
 installQuasarPlugin()
 
@@ -21,6 +63,7 @@ const PlansGroupStub = {
     >
       <div v-for="plan in plans" :key="plan.id" class="plan-item">
         <button @click="$emit('edit', plan.id)" class="edit-btn">Edit</button>
+        <button @click="$emit('export', plan.id)" class="export-btn">Export</button>
         <button @click="$emit('delete', plan)" class="delete-btn">Delete</button>
         <button @click="$emit('share', plan.id)" class="share-btn">Share</button>
         <button @click="$emit('cancel', plan)" class="cancel-btn">Cancel</button>
@@ -28,7 +71,7 @@ const PlansGroupStub = {
     </div>
   `,
   props: ['title', 'plans', 'chipColor', 'hideSharedBadge'],
-  emits: ['edit', 'delete', 'share', 'cancel'],
+  emits: ['edit', 'export', 'delete', 'share', 'cancel'],
 }
 
 const SharePlanDialogStub = {
@@ -43,6 +86,19 @@ const SharePlanDialogStub = {
   `,
   props: ['modelValue', 'planId'],
   emits: ['update:modelValue', 'shared'],
+}
+
+const ExportDialogStub = {
+  template: `
+    <div
+      class="export-dialog-mock"
+      :data-model-value="modelValue"
+    >
+      <button @click="$emit('select-format', 'json')" class="export-json-btn">Export JSON</button>
+    </div>
+  `,
+  props: ['modelValue'],
+  emits: ['update:modelValue', 'select-format'],
 }
 
 const SearchAndSortStub = {
@@ -201,12 +257,32 @@ function createWrapper(
   }
 
   vi.mocked(usePlans).mockReturnValue(mockUsePlansReturn)
+  vi.mocked(getPlanWithItems).mockResolvedValue({
+    id: mockOwnedPlans[0]!.id,
+    name: mockOwnedPlans[0]!.name,
+    template_id: mockOwnedPlans[0]!.template_id,
+    start_date: mockOwnedPlans[0]!.start_date,
+    end_date: mockOwnedPlans[0]!.end_date,
+    status: mockOwnedPlans[0]!.status,
+    total: mockOwnedPlans[0]!.total,
+    currency: mockOwnedPlans[0]!.currency,
+    owner_id: mockOwnedPlans[0]!.owner_id,
+    created_at: mockOwnedPlans[0]!.created_at,
+    updated_at: mockOwnedPlans[0]!.updated_at,
+    ...(mockOwnedPlans[0]!.permission_level
+      ? { permission_level: mockOwnedPlans[0]!.permission_level }
+      : {}),
+    plan_items: [],
+  })
+  vi.mocked(getExpensesByPlan).mockResolvedValue([])
+  vi.mocked(getPlanExpenseSummary).mockResolvedValue([])
 
   const wrapper = mount(PlansPage, {
     global: {
       stubs: {
         PlansGroup: PlansGroupStub,
         SharePlanDialog: SharePlanDialogStub,
+        ExportDialog: ExportDialogStub,
         SearchAndSort: SearchAndSortStub,
         ListPageSkeleton: ListPageSkeletonStub,
         EmptyState: EmptyStateStub,
@@ -253,6 +329,18 @@ beforeEach(() => {
 it('should mount component properly', () => {
   const { wrapper } = createWrapper()
   expect(wrapper.exists()).toBe(true)
+})
+
+it('opens export dialog from plans group export action', async () => {
+  const { wrapper } = createWrapper({
+    ownedPlans: mockOwnedPlans,
+    hasPlans: true,
+  })
+
+  await wrapper.find('.export-btn').trigger('click')
+
+  const exportDialog = wrapper.findComponent(ExportDialogStub)
+  expect(exportDialog.attributes('data-model-value')).toBe('true')
 })
 
 it('should render page title and description', () => {

--- a/src/pages/PlansPage.vue
+++ b/src/pages/PlansPage.vue
@@ -19,6 +19,7 @@
       title="My Plans"
       :plans="allFilteredAndSortedItems"
       @edit="viewItem"
+      @export="openExportDialog"
       @delete="handleDeletePlan"
       @share="openShareDialog"
       @cancel="cancelPlan"
@@ -46,6 +47,11 @@
       :owner-user-id="sharePlanOwnerId"
       @shared="isShareDialogOpen = false"
     />
+
+    <ExportDialog
+      v-model="isExportDialogOpen"
+      @select-format="handlePlanExport"
+    />
   </ListPageLayout>
 </template>
 
@@ -61,8 +67,20 @@ import ListPageSkeleton from 'src/components/shared/ListPageSkeleton.vue'
 import EmptyState from 'src/components/shared/EmptyState.vue'
 import PlansGroup from 'src/components/plans/PlansGroup.vue'
 import SharePlanDialog from 'src/components/plans/SharePlanDialog.vue'
+import ExportDialog from 'src/components/shared/ExportDialog.vue'
 import { usePlans } from 'src/composables/usePlans'
-import type { PlanWithPermission } from 'src/api'
+import { useCategoriesQuery } from 'src/queries/categories'
+import { useUserStore } from 'src/stores/user'
+import { useBanner } from 'src/composables/useBanner'
+import {
+  getExpensesByPlan,
+  getPlanExpenseSummary,
+  getPlanWithItems,
+  type PlanWithPermission,
+  type Category,
+} from 'src/api'
+import { createPlanExportDownload, downloadExportFile, type ExportFormat } from 'src/utils/export'
+import type { CategoryBudget } from 'src/types'
 
 const {
   searchQuery,
@@ -78,13 +96,38 @@ const {
   clearSearch,
   cancelPlan,
 } = usePlans()
+const { categories } = useCategoriesQuery()
+const userStore = useUserStore()
+const { showError, showSuccess } = useBanner()
 
 const isShareDialogOpen = ref(false)
+const isExportDialogOpen = ref(false)
 const sharePlanId = ref<string | null>(null)
+const exportPlanId = ref<string | null>(null)
 const sharePlanOwnerId = computed(() => {
   if (!sharePlanId.value) return undefined
   return allFilteredAndSortedItems.value.find((p) => p.id === sharePlanId.value)?.owner_id
 })
+
+function mapPlanSummaryToCategoryBudgets(
+  summary: Awaited<ReturnType<typeof getPlanExpenseSummary>>,
+  allCategories: Category[],
+): CategoryBudget[] {
+  return summary.map((item) => {
+    const category = allCategories.find((entry) => entry.id === item.category_id)
+
+    return {
+      categoryId: item.category_id,
+      categoryName: category?.name || '',
+      categoryColor: category?.color || '',
+      categoryIcon: category?.icon || 'eva-folder-outline',
+      plannedAmount: item.planned_amount,
+      actualAmount: item.actual_amount,
+      remainingAmount: item.remaining_amount,
+      expenseCount: item.expense_count,
+    }
+  })
+}
 
 function handleDeletePlan(plan: PlanWithPermission): void {
   deleteItem(plan)
@@ -93,5 +136,43 @@ function handleDeletePlan(plan: PlanWithPermission): void {
 function openShareDialog(planId: string): void {
   sharePlanId.value = planId
   isShareDialogOpen.value = true
+}
+
+function openExportDialog(planId: string): void {
+  exportPlanId.value = planId
+  isExportDialogOpen.value = true
+}
+
+async function handlePlanExport(format: ExportFormat): Promise<void> {
+  if (!exportPlanId.value || !userStore.userProfile?.id) {
+    showError('Plan export is unavailable right now.')
+    return
+  }
+
+  try {
+    const [plan, expenses, summary] = await Promise.all([
+      getPlanWithItems(exportPlanId.value, userStore.userProfile.id),
+      getExpensesByPlan(exportPlanId.value),
+      getPlanExpenseSummary(exportPlanId.value),
+    ])
+
+    if (!plan) {
+      throw new Error('PLAN_NOT_FOUND')
+    }
+
+    const download = createPlanExportDownload(
+      plan,
+      categories.value,
+      mapPlanSummaryToCategoryBudgets(summary, categories.value),
+      expenses,
+      format,
+    )
+
+    downloadExportFile(download)
+    isExportDialogOpen.value = false
+    showSuccess(`Plan exported as ${format.toUpperCase()}.`)
+  } catch {
+    showError(`Failed to export plan as ${format.toUpperCase()}.`)
+  }
 }
 </script>

--- a/src/pages/TemplatePage.test.ts
+++ b/src/pages/TemplatePage.test.ts
@@ -270,6 +270,11 @@ function createWrapper(
         TemplateCategory: TemplateCategoryStub,
         CategorySelectionDialog: CategorySelectionDialogStub,
         ShareTemplateDialog: ShareTemplateDialogStub,
+        ExportDialog: {
+          template: '<div class="export-dialog-mock" :data-model-value="modelValue"></div>',
+          props: ['modelValue'],
+          emits: ['update:modelValue', 'select-format'],
+        },
         QForm: {
           template: '<form @submit.prevent="$emit(\'submit\')"><slot /></form>',
           emits: ['submit'],
@@ -562,6 +567,20 @@ describe('TemplatePage', () => {
 
     const shareButton = wrapper.find('[data-label="Share"]')
     expect(shareButton.exists()).toBe(false)
+  })
+
+  it('should show export button in read-only mode', () => {
+    const { wrapper } = createWrapper({ isReadOnlyMode: true })
+
+    const exportButton = wrapper.find('[data-label="Export"]')
+    expect(exportButton.exists()).toBe(true)
+  })
+
+  it('should not show export button for new template', () => {
+    const { wrapper } = createWrapper({ isNewTemplate: true })
+
+    const exportButton = wrapper.find('[data-label="Export"]')
+    expect(exportButton.exists()).toBe(false)
   })
 
   it('should open share dialog when share button is clicked', async () => {

--- a/src/pages/TemplatePage.vue
+++ b/src/pages/TemplatePage.vue
@@ -3,7 +3,7 @@
     :page-title="pageTitle"
     :is-loading="isTemplateLoading"
     :actions="actionBarActions"
-    :actions-visible="isEditMode"
+    :actions-visible="actionsVisible"
     :is-edit-mode="isEditMode"
     :show-read-only-badge="!isEditMode"
     @back="goBack"
@@ -59,6 +59,11 @@
         @shared="onTemplateShared"
       />
 
+      <ExportDialog
+        v-model="isExportDialogOpen"
+        @select-format="handleTemplateExport"
+      />
+
       <DeleteDialog
         v-if="!isNewTemplate"
         v-model="showDeleteDialog"
@@ -82,6 +87,7 @@ import TemplateReadOnlyView from 'src/components/templates/TemplateReadOnlyView.
 import CategorySelectionDialog from 'src/components/categories/CategorySelectionDialog.vue'
 import ShareTemplateDialog from 'src/components/templates/ShareTemplateDialog.vue'
 import DeleteDialog from 'src/components/shared/DeleteDialog.vue'
+import ExportDialog from 'src/components/shared/ExportDialog.vue'
 import { useTemplatePageState } from 'src/composables/useTemplatePageState'
 
 const {
@@ -104,8 +110,10 @@ const {
   form,
   allCategoriesExpanded,
   actionBarActions,
+  actionsVisible,
   showCategoryDialog,
   isShareDialogOpen,
+  isExportDialogOpen,
   showDeleteDialog,
   deleteTemplateMutation,
   getUsedCategoryIds,
@@ -116,6 +124,7 @@ const {
   clearNameError,
   onCategorySelected,
   openCategoryDialog,
+  handleTemplateExport,
   toggleAllCategories,
   goBack,
   onTemplateShared,

--- a/src/pages/TemplatesPage.test.ts
+++ b/src/pages/TemplatesPage.test.ts
@@ -7,6 +7,46 @@ import { useTemplates } from 'src/composables/useTemplates'
 import type { TemplateWithPermission } from 'src/api'
 import { setupTestingPinia } from 'test/helpers/pinia-mocks'
 import { createMockTemplates } from 'test/fixtures'
+import { getTemplateWithItems } from 'src/api'
+
+vi.mock('src/api', async () => {
+  const actual = await vi.importActual('src/api')
+  return {
+    ...actual,
+    getTemplateWithItems: vi.fn(),
+  }
+})
+
+vi.mock('src/queries/categories', () => ({
+  useCategoriesQuery: vi.fn(() => ({
+    categories: ref([
+      {
+        id: 'cat-1',
+        name: 'Food',
+        color: '#FF5722',
+        icon: 'eva-pricetags-outline',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+      },
+    ]),
+  })),
+}))
+
+vi.mock('src/stores/user', () => ({
+  useUserStore: vi.fn(() => ({
+    userProfile: { id: 'user-1' },
+  })),
+}))
+
+const mockTemplatesShowError = vi.fn()
+const mockTemplatesShowSuccess = vi.fn()
+
+vi.mock('src/composables/useBanner', () => ({
+  useBanner: vi.fn(() => ({
+    showError: mockTemplatesShowError,
+    showSuccess: mockTemplatesShowSuccess,
+  })),
+}))
 
 installQuasarPlugin()
 
@@ -23,13 +63,14 @@ const TemplatesGroupStub = {
     >
       <div v-for="template in templates" :key="template.id" class="template-item">
         <button @click="$emit('edit', template.id)" class="edit-btn">Edit</button>
+        <button @click="$emit('export', template.id)" class="export-btn">Export</button>
         <button @click="$emit('delete', template)" class="delete-btn">Delete</button>
         <button @click="$emit('share', template.id)" class="share-btn">Share</button>
       </div>
     </div>
   `,
   props: ['title', 'templates', 'chipColor', 'hideSharedBadge'],
-  emits: ['edit', 'delete', 'share'],
+  emits: ['edit', 'export', 'delete', 'share'],
 }
 
 const ShareTemplateDialogStub = {
@@ -44,6 +85,19 @@ const ShareTemplateDialogStub = {
   `,
   props: ['modelValue', 'templateId'],
   emits: ['update:modelValue', 'shared'],
+}
+
+const ExportDialogStub = {
+  template: `
+    <div
+      class="export-dialog-mock"
+      :data-model-value="modelValue"
+    >
+      <button @click="$emit('select-format', 'json')" class="export-json-btn">Export JSON</button>
+    </div>
+  `,
+  props: ['modelValue'],
+  emits: ['update:modelValue', 'select-format'],
 }
 
 const SearchAndSortStub = {
@@ -168,6 +222,18 @@ function createWrapper(
   }
 
   vi.mocked(useTemplates).mockReturnValue(mockTemplatesReturn)
+  vi.mocked(getTemplateWithItems).mockResolvedValue({
+    id: mockOwnedTemplates[0]!.id,
+    name: mockOwnedTemplates[0]!.name,
+    duration: mockOwnedTemplates[0]!.duration,
+    total: mockOwnedTemplates[0]!.total,
+    currency: mockOwnedTemplates[0]!.currency,
+    owner_id: mockOwnedTemplates[0]!.owner_id,
+    created_at: mockOwnedTemplates[0]!.created_at,
+    updated_at: mockOwnedTemplates[0]!.updated_at,
+    permission_level: mockOwnedTemplates[0]!.permission_level,
+    template_items: [],
+  })
 
   setupTestingPinia({ stubActions: true })
 
@@ -176,6 +242,7 @@ function createWrapper(
       stubs: {
         TemplatesGroup: TemplatesGroupStub,
         ShareTemplateDialog: ShareTemplateDialogStub,
+        ExportDialog: ExportDialogStub,
         SearchAndSort: SearchAndSortStub,
         ListPageSkeleton: ListPageSkeletonStub,
         EmptyState: EmptyStateStub,
@@ -222,6 +289,18 @@ beforeEach(() => {
 it('should mount component properly', () => {
   const { wrapper } = createWrapper()
   expect(wrapper.exists()).toBe(true)
+})
+
+it('opens export dialog from templates group export action', async () => {
+  const { wrapper } = createWrapper({
+    ownedTemplates: mockOwnedTemplates,
+    hasTemplates: true,
+  })
+
+  await wrapper.find('.export-btn').trigger('click')
+
+  const exportDialog = wrapper.findComponent(ExportDialogStub)
+  expect(exportDialog.attributes('data-model-value')).toBe('true')
 })
 
 it('should render page title and description', () => {

--- a/src/pages/TemplatesPage.vue
+++ b/src/pages/TemplatesPage.vue
@@ -19,6 +19,7 @@
       title="My Templates"
       :templates="allFilteredAndSortedItems"
       @edit="viewItem"
+      @export="openExportDialog"
       @delete="deleteItem"
       @share="openShareDialog"
     />
@@ -45,6 +46,11 @@
       :owner-user-id="shareTemplateOwnerId"
       @shared="isShareDialogOpen = false"
     />
+
+    <ExportDialog
+      v-model="isExportDialogOpen"
+      @select-format="handleTemplateExport"
+    />
   </ListPageLayout>
 </template>
 
@@ -60,7 +66,17 @@ import ListPageSkeleton from 'src/components/shared/ListPageSkeleton.vue'
 import EmptyState from 'src/components/shared/EmptyState.vue'
 import TemplatesGroup from 'src/components/templates/TemplatesGroup.vue'
 import ShareTemplateDialog from 'src/components/templates/ShareTemplateDialog.vue'
+import ExportDialog from 'src/components/shared/ExportDialog.vue'
 import { useTemplates } from 'src/composables/useTemplates'
+import { useCategoriesQuery } from 'src/queries/categories'
+import { useUserStore } from 'src/stores/user'
+import { useBanner } from 'src/composables/useBanner'
+import { getTemplateWithItems } from 'src/api'
+import {
+  createTemplateExportDownload,
+  downloadExportFile,
+  type ExportFormat,
+} from 'src/utils/export'
 
 const {
   searchQuery,
@@ -75,9 +91,14 @@ const {
   deleteItem,
   clearSearch,
 } = useTemplates()
+const { categories } = useCategoriesQuery()
+const userStore = useUserStore()
+const { showError, showSuccess } = useBanner()
 
 const isShareDialogOpen = ref(false)
+const isExportDialogOpen = ref(false)
 const shareTemplateId = ref<string | null>(null)
+const exportTemplateId = ref<string | null>(null)
 const shareTemplateOwnerId = computed(() => {
   if (!shareTemplateId.value) return undefined
   return allFilteredAndSortedItems.value.find((t) => t.id === shareTemplateId.value)?.owner_id
@@ -86,5 +107,33 @@ const shareTemplateOwnerId = computed(() => {
 function openShareDialog(templateId: string): void {
   shareTemplateId.value = templateId
   isShareDialogOpen.value = true
+}
+
+function openExportDialog(templateId: string): void {
+  exportTemplateId.value = templateId
+  isExportDialogOpen.value = true
+}
+
+async function handleTemplateExport(format: ExportFormat): Promise<void> {
+  if (!exportTemplateId.value || !userStore.userProfile?.id) {
+    showError('Template export is unavailable right now.')
+    return
+  }
+
+  try {
+    const template = await getTemplateWithItems(exportTemplateId.value, userStore.userProfile.id)
+
+    if (!template) {
+      throw new Error('TEMPLATE_NOT_FOUND')
+    }
+
+    const download = createTemplateExportDownload(template, categories.value, format)
+
+    downloadExportFile(download)
+    isExportDialogOpen.value = false
+    showSuccess(`Template exported as ${format.toUpperCase()}.`)
+  } catch {
+    showError(`Failed to export template as ${format.toUpperCase()}.`)
+  }
 }
 </script>

--- a/src/utils/export.test.ts
+++ b/src/utils/export.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+import type { Category, ExpenseWithCategory, PlanWithItems, TemplateWithItems } from 'src/api'
+import type { CategoryBudget } from 'src/types'
+import {
+  createPlanExportDownload,
+  createPlanExportPayload,
+  createTemplateExportDownload,
+  createTemplateExportPayload,
+} from './export'
+
+const categories: Category[] = [
+  {
+    id: 'cat-1',
+    name: 'Food & Dining',
+    color: '#FF5722',
+    icon: 'eva-pricetags-outline',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  },
+]
+
+const template: TemplateWithItems = {
+  id: 'template-1',
+  name: 'Monthly Budget',
+  duration: 'monthly',
+  currency: 'USD',
+  total: 1500,
+  owner_id: 'user-1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-02T00:00:00Z',
+  template_items: [
+    {
+      id: 'item-1',
+      template_id: 'template-1',
+      name: 'Groceries, Home',
+      category_id: 'cat-1',
+      amount: 500,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      is_fixed_payment: true,
+    },
+  ],
+}
+
+const plan: PlanWithItems = {
+  id: 'plan-1',
+  name: 'Q2 Budget',
+  template_id: 'template-1',
+  start_date: '2024-06-01',
+  end_date: '2024-06-30',
+  status: 'active',
+  currency: 'USD',
+  total: 1500,
+  owner_id: 'user-1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-02T00:00:00Z',
+  plan_items: [
+    {
+      id: 'plan-item-1',
+      plan_id: 'plan-1',
+      name: 'Groceries "Weekly"',
+      category_id: 'cat-1',
+      amount: 500,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      is_completed: false,
+      is_fixed_payment: true,
+    },
+  ],
+}
+
+const categoryBudgets: CategoryBudget[] = [
+  {
+    categoryId: 'cat-1',
+    categoryName: 'Food & Dining',
+    categoryColor: '#FF5722',
+    categoryIcon: 'eva-pricetags-outline',
+    plannedAmount: 500,
+    actualAmount: 120.75,
+    remainingAmount: 379.25,
+    expenseCount: 2,
+  },
+]
+
+const expenses: ExpenseWithCategory[] = [
+  {
+    id: 'expense-1',
+    name: 'Market run',
+    amount: 45.5,
+    currency: 'USD',
+    original_amount: null,
+    original_currency: null,
+    expense_date: '2024-06-03',
+    category_id: 'cat-1',
+    plan_id: 'plan-1',
+    plan_item_id: 'plan-item-1',
+    user_id: 'user-1',
+    created_at: '2024-06-03T10:00:00Z',
+    updated_at: '2024-06-03T10:00:00Z',
+    categories: categories[0]!,
+  },
+]
+
+describe('export utils', () => {
+  it('builds template JSON payload with category details', () => {
+    const payload = createTemplateExportPayload(template, categories, '2026-04-13T12:00:00.000Z')
+
+    expect(payload.schema_version).toBe('1.0')
+    expect(payload.items).toEqual([
+      expect.objectContaining({
+        id: 'item-1',
+        category_name: 'Food & Dining',
+        category_color: '#FF5722',
+      }),
+    ])
+  })
+
+  it('builds template CSV download with escaped item names', () => {
+    const download = createTemplateExportDownload(
+      template,
+      categories,
+      'csv',
+      '2026-04-13T12:00:00.000Z',
+    )
+
+    expect(download.filename).toBe('template_monthly-budget_2026-04-13.csv')
+    expect(download.content).toContain('"Groceries, Home"')
+    expect(download.content.split('\n')[0]).toContain('template_id')
+  })
+
+  it('builds plan JSON payload with category summary and expenses', () => {
+    const payload = createPlanExportPayload(
+      plan,
+      categories,
+      categoryBudgets,
+      expenses,
+      '2026-04-13T12:00:00.000Z',
+    )
+
+    expect(payload.category_summary).toEqual([
+      expect.objectContaining({
+        category_id: 'cat-1',
+        actual_amount: 120.75,
+        expense_count: 2,
+      }),
+    ])
+    expect(payload.expenses).toEqual([
+      expect.objectContaining({
+        id: 'expense-1',
+        category_name: 'Food & Dining',
+      }),
+    ])
+  })
+
+  it('builds plan CSV download with aggregate category columns', () => {
+    const download = createPlanExportDownload(
+      plan,
+      categories,
+      categoryBudgets,
+      expenses,
+      'csv',
+      '2026-04-13T12:00:00.000Z',
+    )
+
+    expect(download.filename).toBe('plan_q2-budget_2026-04-13.csv')
+    expect(download.content.split('\n')[0]).toContain('category_actual_amount')
+    expect(download.content).toContain('"Groceries ""Weekly"""')
+    expect(download.content).toContain('120.75')
+    expect(download.content).toContain('379.25')
+  })
+})

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,0 +1,404 @@
+import type { Category, ExpenseWithCategory, PlanWithItems, TemplateWithItems } from 'src/api'
+import type { CategoryBudget } from 'src/types'
+
+export type ExportFormat = 'json' | 'csv'
+
+export type ExportDownload = {
+  filename: string
+  mimeType: string
+  content: string
+}
+
+export type ExportItemRecord = {
+  id: string
+  name: string
+  category_id: string
+  category_name: string
+  category_color: string | null
+  category_icon: string | null
+  amount: number
+  is_fixed_payment: boolean
+}
+
+export type TemplateExportPayload = {
+  schema_version: string
+  exported_at: string
+  entity_type: 'template'
+  template: {
+    id: string
+    name: string
+    duration: string
+    currency: string | null
+    total: number | null
+    owner_id: string
+    created_at: string
+    updated_at: string | null
+  }
+  items: ExportItemRecord[]
+}
+
+export type PlanExportCategorySummary = {
+  category_id: string
+  category_name: string
+  category_color: string | null
+  category_icon: string | null
+  planned_amount: number
+  actual_amount: number
+  remaining_amount: number
+  expense_count: number
+}
+
+export type PlanExportExpense = {
+  id: string
+  name: string
+  category_id: string
+  category_name: string
+  category_color: string | null
+  category_icon: string | null
+  amount: number
+  currency: string | null
+  original_amount: number | null
+  original_currency: string | null
+  expense_date: string
+  plan_item_id: string | null
+  created_at: string
+  updated_at: string | null
+}
+
+export type PlanExportPayload = {
+  schema_version: string
+  exported_at: string
+  entity_type: 'plan'
+  plan: {
+    id: string
+    name: string
+    template_id: string | null
+    start_date: string
+    end_date: string
+    status: string | null
+    currency: string | null
+    total: number | null
+    owner_id: string
+    created_at: string
+    updated_at: string | null
+  }
+  items: ExportItemRecord[]
+  category_summary: PlanExportCategorySummary[]
+  expenses: PlanExportExpense[]
+}
+
+const EXPORT_SCHEMA_VERSION = '1.0'
+
+type CategoryLookup = Map<string, Category>
+
+function buildCategoryLookup(categories: Category[]): CategoryLookup {
+  return new Map(categories.map((category) => [category.id, category]))
+}
+
+function toDateStamp(date: string): string {
+  return date.slice(0, 10)
+}
+
+function slugifyFilePart(value: string, fallback: string): string {
+  const normalized = value
+    .normalize('NFKD')
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return normalized || fallback
+}
+
+function toExportItemRecord(
+  item: {
+    id: string
+    name: string
+    category_id: string
+    amount: number
+    is_fixed_payment?: boolean | null
+  },
+  categoryLookup: CategoryLookup,
+): ExportItemRecord {
+  const category = categoryLookup.get(item.category_id)
+
+  return {
+    id: item.id,
+    name: item.name,
+    category_id: item.category_id,
+    category_name: category?.name || '',
+    category_color: category?.color || null,
+    category_icon: category?.icon || null,
+    amount: item.amount,
+    is_fixed_payment: item.is_fixed_payment ?? true,
+  }
+}
+
+function escapeCsvValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  const stringValue =
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+      ? String(value)
+      : JSON.stringify(value)
+  if (!/[",\n]/.test(stringValue)) {
+    return stringValue
+  }
+
+  return `"${stringValue.replace(/"/g, '""')}"`
+}
+
+function buildCsv(columns: string[], rows: Array<Record<string, unknown>>): string {
+  const header = columns.join(',')
+  const lines = rows.map((row) => columns.map((column) => escapeCsvValue(row[column])).join(','))
+
+  return [header, ...lines].join('\n')
+}
+
+function createExportDownload(
+  filename: string,
+  format: ExportFormat,
+  payload: object,
+  csvBuilder: () => string,
+): ExportDownload {
+  if (format === 'json') {
+    return {
+      filename: `${filename}.json`,
+      mimeType: 'application/json',
+      content: JSON.stringify(payload, null, 2),
+    }
+  }
+
+  return {
+    filename: `${filename}.csv`,
+    mimeType: 'text/csv;charset=utf-8',
+    content: csvBuilder(),
+  }
+}
+
+export function createTemplateExportPayload(
+  template: TemplateWithItems,
+  categories: Category[],
+  exportedAt = new Date().toISOString(),
+): TemplateExportPayload {
+  const categoryLookup = buildCategoryLookup(categories)
+
+  return {
+    schema_version: EXPORT_SCHEMA_VERSION,
+    exported_at: exportedAt,
+    entity_type: 'template',
+    template: {
+      id: template.id,
+      name: template.name,
+      duration: template.duration,
+      currency: template.currency,
+      total: template.total,
+      owner_id: template.owner_id,
+      created_at: template.created_at,
+      updated_at: template.updated_at,
+    },
+    items: template.template_items.map((item) => toExportItemRecord(item, categoryLookup)),
+  }
+}
+
+export function createPlanExportPayload(
+  plan: PlanWithItems,
+  categories: Category[],
+  categoryBudgets: CategoryBudget[],
+  expenses: ExpenseWithCategory[],
+  exportedAt = new Date().toISOString(),
+): PlanExportPayload {
+  const categoryLookup = buildCategoryLookup(categories)
+
+  return {
+    schema_version: EXPORT_SCHEMA_VERSION,
+    exported_at: exportedAt,
+    entity_type: 'plan',
+    plan: {
+      id: plan.id,
+      name: plan.name,
+      template_id: plan.template_id,
+      start_date: plan.start_date,
+      end_date: plan.end_date,
+      status: plan.status,
+      currency: plan.currency,
+      total: plan.total,
+      owner_id: plan.owner_id,
+      created_at: plan.created_at,
+      updated_at: plan.updated_at,
+    },
+    items: plan.plan_items.map((item) => toExportItemRecord(item, categoryLookup)),
+    category_summary: categoryBudgets.map((budget) => ({
+      category_id: budget.categoryId,
+      category_name: budget.categoryName,
+      category_color: budget.categoryColor || null,
+      category_icon: budget.categoryIcon || null,
+      planned_amount: budget.plannedAmount,
+      actual_amount: budget.actualAmount,
+      remaining_amount: budget.remainingAmount,
+      expense_count: budget.expenseCount,
+    })),
+    expenses: expenses.map((expense) => ({
+      id: expense.id,
+      name: expense.name,
+      category_id: expense.category_id,
+      category_name: expense.categories?.name || '',
+      category_color: expense.categories?.color || null,
+      category_icon: expense.categories?.icon || null,
+      amount: expense.amount,
+      currency: expense.currency,
+      original_amount: expense.original_amount,
+      original_currency: expense.original_currency,
+      expense_date: expense.expense_date,
+      plan_item_id: expense.plan_item_id,
+      created_at: expense.created_at,
+      updated_at: expense.updated_at,
+    })),
+  }
+}
+
+export function createTemplateExportDownload(
+  template: TemplateWithItems,
+  categories: Category[],
+  format: ExportFormat,
+  exportedAt = new Date().toISOString(),
+): ExportDownload {
+  const payload = createTemplateExportPayload(template, categories, exportedAt)
+  const filename = `template_${slugifyFilePart(template.name, 'template')}_${toDateStamp(exportedAt)}`
+
+  return createExportDownload(filename, format, payload, () =>
+    buildCsv(
+      [
+        'schema_version',
+        'exported_at',
+        'template_id',
+        'template_name',
+        'duration',
+        'currency',
+        'total',
+        'item_id',
+        'item_name',
+        'category_id',
+        'category_name',
+        'category_color',
+        'category_icon',
+        'amount',
+        'is_fixed_payment',
+      ],
+      payload.items.map((item) => ({
+        schema_version: payload.schema_version,
+        exported_at: payload.exported_at,
+        template_id: payload.template.id,
+        template_name: payload.template.name,
+        duration: payload.template.duration,
+        currency: payload.template.currency,
+        total: payload.template.total,
+        item_id: item.id,
+        item_name: item.name,
+        category_id: item.category_id,
+        category_name: item.category_name,
+        category_color: item.category_color,
+        category_icon: item.category_icon,
+        amount: item.amount,
+        is_fixed_payment: item.is_fixed_payment,
+      })),
+    ),
+  )
+}
+
+export function createPlanExportDownload(
+  plan: PlanWithItems,
+  categories: Category[],
+  categoryBudgets: CategoryBudget[],
+  expenses: ExpenseWithCategory[],
+  format: ExportFormat,
+  exportedAt = new Date().toISOString(),
+): ExportDownload {
+  const payload = createPlanExportPayload(plan, categories, categoryBudgets, expenses, exportedAt)
+  const filename = `plan_${slugifyFilePart(plan.name, 'plan')}_${toDateStamp(exportedAt)}`
+  const categorySummaryById = new Map(
+    payload.category_summary.map((summary) => [summary.category_id, summary]),
+  )
+
+  return createExportDownload(filename, format, payload, () =>
+    buildCsv(
+      [
+        'schema_version',
+        'exported_at',
+        'plan_id',
+        'plan_name',
+        'status',
+        'start_date',
+        'end_date',
+        'currency',
+        'total',
+        'item_id',
+        'item_name',
+        'category_id',
+        'category_name',
+        'category_color',
+        'category_icon',
+        'amount',
+        'is_fixed_payment',
+        'category_actual_amount',
+        'category_remaining_amount',
+        'category_expense_count',
+      ],
+      payload.items.map((item) => {
+        const summary = categorySummaryById.get(item.category_id)
+
+        return {
+          schema_version: payload.schema_version,
+          exported_at: payload.exported_at,
+          plan_id: payload.plan.id,
+          plan_name: payload.plan.name,
+          status: payload.plan.status,
+          start_date: payload.plan.start_date,
+          end_date: payload.plan.end_date,
+          currency: payload.plan.currency,
+          total: payload.plan.total,
+          item_id: item.id,
+          item_name: item.name,
+          category_id: item.category_id,
+          category_name: item.category_name,
+          category_color: item.category_color,
+          category_icon: item.category_icon,
+          amount: item.amount,
+          is_fixed_payment: item.is_fixed_payment,
+          category_actual_amount: summary?.actual_amount ?? 0,
+          category_remaining_amount: summary?.remaining_amount ?? 0,
+          category_expense_count: summary?.expense_count ?? 0,
+        }
+      }),
+    ),
+  )
+}
+
+export function downloadExportFile(download: ExportDownload): void {
+  if (
+    typeof document === 'undefined' ||
+    typeof URL === 'undefined' ||
+    typeof URL.createObjectURL !== 'function'
+  ) {
+    throw new Error('EXPORT_DOWNLOAD_UNSUPPORTED')
+  }
+
+  const blob = new Blob([download.content], { type: download.mimeType })
+  const objectUrl = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+
+  link.href = objectUrl
+  link.download = download.filename
+  link.style.display = 'none'
+
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(objectUrl)
+}


### PR DESCRIPTION
Add export actions and dialogs across plan and template list/detail pages, plus shared export payload utilities and tests. Also clean up lint-safe test and CSV export handling so lint, type-check, format, and unit tests pass.