### PR TITLE
feat: mobile-first UI redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     />
     <meta
       name="theme-color"
-      content="#0a0a0a"
+      content="#121212"
       media="(prefers-color-scheme: dark)"
     />
     <style>
@@ -71,7 +71,7 @@
       }
 
       html[data-boot-theme='dark'] #app-boot {
-        background: #0a0a0a;
+        background: #121212;
       }
 
       #app-boot::before {

--- a/src/api/expenses.ts
+++ b/src/api/expenses.ts
@@ -8,6 +8,10 @@ export type ExpenseWithCategory = Expense & {
   categories: Tables<'categories'>
 }
 
+export type ExpenseWithCategoryAndPlan = ExpenseWithCategory & {
+  plans: Pick<Tables<'plans'>, 'id' | 'name' | 'currency'> | null
+}
+
 export type PlanExpenseSummary = {
   category_id: string
   planned_amount: number
@@ -31,6 +35,22 @@ export async function getExpensesByPlan(planId: string): Promise<ExpenseWithCate
     .eq('plan_id', planId)
     .order('expense_date', { ascending: false })
     .order('created_at', { ascending: false })
+
+  if (error) throw error
+  return data || []
+}
+
+export async function getRecentExpensesForUser(
+  userId: string,
+  limit = 100,
+): Promise<ExpenseWithCategoryAndPlan[]> {
+  const { data, error } = await expenseService.supabase
+    .from('expenses')
+    .select('*, categories(*), plans(id, name, currency)')
+    .eq('user_id', userId)
+    .order('expense_date', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(limit)
 
   if (error) throw error
   return data || []

--- a/src/boot/addressbar-color.ts
+++ b/src/boot/addressbar-color.ts
@@ -3,7 +3,7 @@ import { AddressbarColor, Dark } from 'quasar'
 import { watch } from 'vue'
 
 const LIGHT_COLOR = '#009199'
-const DARK_COLOR = '#1a1a2e'
+const DARK_COLOR = '#121212'
 
 export default boot(() => {
   AddressbarColor.set(Dark.isActive ? DARK_COLOR : LIGHT_COLOR)

--- a/src/components/EmailOtpForm.vue
+++ b/src/components/EmailOtpForm.vue
@@ -6,7 +6,7 @@
     <!-- Error Banners -->
     <q-banner
       v-if="emailError"
-      class="bg-red-1 text-red-9 q-mb-md"
+      class="bg-destructive-soft text-destructive-strong q-mb-md"
       rounded
       dense
     >
@@ -21,7 +21,7 @@
 
     <q-banner
       v-if="otpError"
-      class="bg-red-1 text-red-9 q-mb-md"
+      class="bg-destructive-soft text-destructive-strong q-mb-md"
       rounded
       dense
     >

--- a/src/components/GoogleAuthButton.vue
+++ b/src/components/GoogleAuthButton.vue
@@ -35,7 +35,7 @@
         color="primary"
         size="1.5em"
       />
-      <span class="text-body2 text-grey-7">Preparing secure authentication...</span>
+      <span class="text-body2 text-muted">Preparing secure authentication...</span>
     </div>
   </div>
 </template>

--- a/src/components/MobileBottomNavigation.test.ts
+++ b/src/components/MobileBottomNavigation.test.ts
@@ -64,7 +64,7 @@ it('renders all navigation buttons', () => {
   expect(buttons.length).toBeGreaterThanOrEqual(5)
   expect(buttons.some((btn) => btn.text().includes('Home'))).toBe(true)
   expect(buttons.some((btn) => btn.text().includes('Plans'))).toBe(true)
-  expect(buttons.some((btn) => btn.text().includes('Templates'))).toBe(true)
+  expect(buttons.some((btn) => btn.text().includes('Activity'))).toBe(true)
   expect(buttons.some((btn) => btn.text().includes('Settings'))).toBe(true)
 })
 
@@ -84,12 +84,12 @@ it('highlights plans button when on plans route', () => {
   expect(plansButton?.attributes('data-color')).toBe('primary')
 })
 
-it('highlights templates button when on templates route', () => {
-  mockRoute.fullPath = '/templates'
+it('highlights activity button when on expenses route', () => {
+  mockRoute.fullPath = '/expenses'
   const wrapper = createWrapper()
 
-  const templatesButton = wrapper.findAll('.q-btn').find((btn) => btn.text().includes('Templates'))
-  expect(templatesButton?.attributes('data-color')).toBe('primary')
+  const activityButton = wrapper.findAll('.q-btn').find((btn) => btn.text().includes('Activity'))
+  expect(activityButton?.attributes('data-color')).toBe('primary')
 })
 
 it('does not highlight home button when on subroute', () => {
@@ -119,12 +119,12 @@ it('sets correct to attributes for navigation buttons', () => {
 
   const homeButton = buttons.find((btn) => btn.text().includes('Home'))
   const plansButton = buttons.find((btn) => btn.text().includes('Plans'))
-  const templatesButton = buttons.find((btn) => btn.text().includes('Templates'))
+  const activityButton = buttons.find((btn) => btn.text().includes('Activity'))
   const settingsButton = buttons.find((btn) => btn.text().includes('Settings'))
 
   expect(homeButton?.attributes('data-to')).toBe('/')
   expect(plansButton?.attributes('data-to')).toBe('/plans')
-  expect(templatesButton?.attributes('data-to')).toBe('/templates')
+  expect(activityButton?.attributes('data-to')).toBe('/expenses')
   expect(settingsButton?.attributes('data-to')).toBe('/settings')
 })
 

--- a/src/components/MobileBottomNavigation.vue
+++ b/src/components/MobileBottomNavigation.vue
@@ -52,13 +52,13 @@
         />
       </div>
 
-      <!-- Templates -->
+      <!-- Activity -->
       <div class="mobile-nav-col min-w-0">
         <q-btn
-          icon="eva-file-text-outline"
-          label="Templates"
-          to="/templates"
-          :color="isActive('/templates') ? 'primary' : undefined"
+          icon="eva-activity-outline"
+          label="Activity"
+          to="/expenses"
+          :color="isActive('/expenses') ? 'primary' : undefined"
           :ripple="false"
           size="sm"
           flat
@@ -99,7 +99,7 @@ const { isActive } = useRouteActive()
 
 const activeSlot = computed(() => {
   if (isActive('/settings')) return 4
-  if (isActive('/templates')) return 3
+  if (isActive('/expenses')) return 3
   if (isActive('/plans')) return 1
   return 0
 })

--- a/src/components/UserAvatar.vue
+++ b/src/components/UserAvatar.vue
@@ -15,7 +15,7 @@
   </q-avatar>
   <q-avatar
     v-else
-    color="grey-4"
+    class="bg-muted"
     text-color="primary"
     :size="size"
   >

--- a/src/components/auth/AuthLoginCard.vue
+++ b/src/components/auth/AuthLoginCard.vue
@@ -19,7 +19,7 @@
       </q-avatar>
 
       <div class="text-h5 text-weight-medium q-mb-xs">Welcome to Shephard</div>
-      <div class="text-body2 text-grey-7">Sign in to your account to continue</div>
+      <div class="text-body2 text-muted">Sign in to your account to continue</div>
     </q-card-section>
 
     <q-card-section>

--- a/src/components/categories/CategoryPreviewDialog.vue
+++ b/src/components/categories/CategoryPreviewDialog.vue
@@ -109,15 +109,10 @@
           <q-icon
             name="eva-grid-outline"
             size="3rem"
-            :class="$q.dark.isActive ? 'text-grey-5 q-mb-md' : 'text-grey-4 q-mb-md'"
+            class="text-faint q-mb-md"
           />
-          <div
-            class="text-body1 q-mb-sm"
-            :class="$q.dark.isActive ? 'text-grey-4' : 'text-grey-6'"
-          >
-            No templates use this category yet
-          </div>
-          <div class="text-body2 text-grey-5">Templates using this category will appear here</div>
+          <div class="text-body1 q-mb-sm text-muted">No templates use this category yet</div>
+          <div class="text-body2 text-faint">Templates using this category will appear here</div>
         </q-card>
       </q-card-section>
     </div>

--- a/src/components/categories/CategorySelectionDialog.vue
+++ b/src/components/categories/CategorySelectionDialog.vue
@@ -61,9 +61,9 @@
               <q-icon
                 name="eva-grid-outline"
                 size="2rem"
-                class="text-grey-4 q-mb-sm"
+                class="text-faint q-mb-sm"
               />
-              <div class="text-body2 text-grey-6">
+              <div class="text-body2 text-muted">
                 {{
                   searchQuery
                     ? 'No categories match your search'

--- a/src/components/dashboard/BudgetOverviewCard.vue
+++ b/src/components/dashboard/BudgetOverviewCard.vue
@@ -1,9 +1,11 @@
 <template>
   <q-card
-    clickable
-    :bordered="$q.dark.isActive"
-    class="shadow-1 cursor-pointer"
+    class="budget-hero-card cursor-pointer"
+    role="button"
+    tabindex="0"
+    :aria-label="`Open plan ${plan.name}`"
     @click="emit('click', plan.id)"
+    @keyup.enter="emit('click', plan.id)"
   >
     <q-card-section>
       <!-- Loading state -->
@@ -12,49 +14,43 @@
           <q-skeleton
             type="text"
             width="40%"
+            dark
           />
           <q-skeleton
             type="QChip"
             width="80px"
+            dark
           />
         </div>
-        <div class="row q-col-gutter-sm q-mb-sm">
-          <div
-            v-for="n in 3"
-            :key="n"
-            class="col"
-          >
-            <q-skeleton
-              type="text"
-              width="60%"
-            />
-            <q-skeleton
-              type="text"
-              width="80%"
-            />
-          </div>
-        </div>
+        <q-skeleton
+          type="text"
+          width="55%"
+          height="48px"
+          dark
+        />
         <q-skeleton
           type="rect"
           height="8px"
+          class="q-mt-md"
+          dark
         />
         <q-skeleton
           type="text"
           width="50%"
           class="q-mt-xs"
+          dark
         />
       </template>
 
       <!-- Loaded state -->
       <template v-else>
         <!-- Row 1: Plan name + status chip -->
-        <div class="row items-center justify-between q-mb-md">
-          <div class="text-subtitle1 text-weight-medium ellipsis col">
+        <div class="row items-center justify-between no-wrap q-mb-sm">
+          <div class="budget-hero-card__plan-name ellipsis col">
             {{ plan.name }}
           </div>
           <q-chip
-            :color="getStatusColor(plan)"
-            text-color="white"
+            class="budget-hero-card__chip"
             size="sm"
             square
           >
@@ -62,43 +58,31 @@
           </q-chip>
         </div>
 
-        <!-- Row 2: Three metrics -->
-        <div class="row q-col-gutter-sm q-mb-sm">
-          <div class="col">
-            <div class="text-caption text-grey-6">Spent</div>
-            <div class="text-weight-bold text-info">
-              {{ formatAmount(totalSpent) }}
-            </div>
-          </div>
-          <div class="col">
-            <div class="text-caption text-grey-6">Budget</div>
-            <div class="text-weight-bold">
-              {{ formatAmount(totalBudget) }}
-            </div>
-          </div>
-          <div class="col">
-            <div class="text-caption text-grey-6">
-              {{ remainingBudget >= 0 ? 'Remaining' : 'Over' }}
-            </div>
-            <div
-              class="text-weight-bold"
-              :class="remainingColorClass"
-            >
-              {{ formatAmount(Math.abs(remainingBudget)) }}
-            </div>
-          </div>
+        <!-- Row 2: Hero metric -->
+        <div class="budget-hero-card__overline section-overline">
+          {{ isOverBudget ? 'Over budget' : 'Left to spend' }}
+        </div>
+        <div class="text-display budget-hero-card__amount">
+          <q-icon
+            v-if="isOverBudget"
+            name="eva-alert-triangle-outline"
+            size="28px"
+            class="q-mr-xs"
+          />
+          {{ heroAmount }}
         </div>
 
-        <!-- Row 3: Progress bar -->
+        <!-- Row 3: Progress -->
         <q-linear-progress
           :value="overallProgress"
-          :color="progressColor"
+          :aria-label="`${Math.round(progressPercentage)}% of budget spent`"
+          class="budget-hero-card__progress q-mt-md"
           size="8px"
         />
 
         <!-- Row 4: Caption with percentage + days remaining -->
-        <div class="text-caption text-grey-6 q-mt-xs">
-          {{ Math.round(progressPercentage) }}% of budget spent
+        <div class="budget-hero-card__caption text-caption q-mt-xs">
+          {{ Math.round(progressPercentage) }}% of {{ formatAmount(totalBudget) }} spent
           <template v-if="daysRemaining !== null">
             &middot; {{ daysRemaining }} day{{ daysRemaining === 1 ? '' : 's' }} left
           </template>
@@ -114,9 +98,14 @@ import { usePlanDetailQuery } from 'src/queries/plans'
 import { useUserStore } from 'src/stores/user'
 import { usePreferencesStore } from 'src/stores/preferences'
 import { usePlanOverview } from 'src/composables/usePlanOverview'
-import { getStatusColor, getStatusText, getDaysRemaining } from 'src/utils/plans'
-import { getBudgetProgressColor, getBudgetRemainingColorClass } from 'src/utils/budget'
-import { formatCurrency, formatCurrencyPrivate, type CurrencyCode } from 'src/utils/currency'
+import { useCountUp } from 'src/composables/useCountUp'
+import { getStatusText, getDaysRemaining } from 'src/utils/plans'
+import {
+  formatCurrency,
+  formatCurrencyPrivate,
+  formatCurrencyWithSign,
+  type CurrencyCode,
+} from 'src/utils/currency'
 import type { PlanWithPermission } from 'src/api'
 
 const emit = defineEmits<{
@@ -143,17 +132,30 @@ const { totalBudget, totalSpent, remainingBudget } = usePlanOverview(
 
 const daysRemaining = computed(() => getDaysRemaining(props.plan))
 
+const isOverBudget = computed(() => remainingBudget.value < 0)
+
 const progressPercentage = computed(() => {
   if (totalBudget.value === 0) return 0
   return (totalSpent.value / totalBudget.value) * 100
 })
 
-const progressColor = computed(() => getBudgetProgressColor(progressPercentage.value))
-const remainingColorClass = computed(() => getBudgetRemainingColorClass(progressPercentage.value))
-
 const overallProgress = computed(() => {
   if (totalBudget.value === 0) return 0
   return Math.min(totalSpent.value / totalBudget.value, 1)
+})
+
+const { displayValue: animatedRemaining } = useCountUp(remainingBudget, {
+  enabled: () => !preferencesStore.isPrivacyModeEnabled,
+})
+
+const heroAmount = computed(() => {
+  const currency = props.plan.currency as CurrencyCode
+
+  if (preferencesStore.isPrivacyModeEnabled) {
+    return formatCurrencyPrivate(currency)
+  }
+
+  return formatCurrencyWithSign(animatedRemaining.value, currency)
 })
 
 function formatAmount(amount: number | null | undefined): string {
@@ -166,3 +168,49 @@ function formatAmount(amount: number | null | undefined): string {
   return formatCurrency(amount, currency)
 }
 </script>
+
+<style lang="scss" scoped>
+.budget-hero-card {
+  border-radius: var(--radius-xl);
+  border: none;
+  color: hsl(var(--hero-foreground));
+  background:
+    radial-gradient(120% 140% at 85% -20%, hsl(var(--hero-glow)) 0%, transparent 55%),
+    linear-gradient(135deg, hsl(var(--hero-gradient-from)) 0%, hsl(var(--hero-gradient-to)) 100%);
+  box-shadow: var(--shadow-md);
+}
+
+.budget-hero-card__plan-name {
+  color: hsl(var(--hero-muted));
+  font-weight: 500;
+}
+
+.budget-hero-card__chip {
+  background: hsl(var(--hero-track));
+  color: hsl(var(--hero-foreground));
+}
+
+.budget-hero-card__overline {
+  color: hsl(var(--hero-muted));
+}
+
+.budget-hero-card__amount {
+  color: hsl(var(--hero-foreground));
+  display: flex;
+  align-items: center;
+}
+
+.budget-hero-card__caption {
+  color: hsl(var(--hero-muted));
+}
+
+.budget-hero-card__progress {
+  border-radius: var(--radius-full);
+  color: hsl(var(--hero-foreground));
+
+  :deep(.q-linear-progress__track) {
+    background: hsl(var(--hero-track));
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/dashboard/DashboardHeader.test.ts
+++ b/src/components/dashboard/DashboardHeader.test.ts
@@ -129,7 +129,7 @@ describe('DashboardHeader', () => {
     const wrapper = createWrapper()
     const subtitle = wrapper.find('p')
     expect(subtitle.classes()).toContain('q-ma-none')
-    expect(subtitle.classes()).toContain('text-grey-6')
+    expect(subtitle.classes()).toContain('text-muted')
     expect(subtitle.classes()).toContain('text-body1')
   })
 

--- a/src/components/dashboard/DashboardHeader.vue
+++ b/src/components/dashboard/DashboardHeader.vue
@@ -8,7 +8,7 @@
     </h1>
     <p
       v-if="!$q.screen.lt.md"
-      class="q-ma-none text-grey-6 text-body1"
+      class="q-ma-none text-muted text-body1"
     >
       What would you like to do today?
     </p>

--- a/src/components/dashboard/EmptyPlansState.test.ts
+++ b/src/components/dashboard/EmptyPlansState.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { describe, it, expect } from 'vitest'
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest'
 import EmptyPlansState from './EmptyPlansState.vue'
+import BrandIllustration from 'src/components/shared/BrandIllustration.vue'
 
 installQuasarPlugin()
 
@@ -30,11 +31,12 @@ describe('EmptyPlansState', () => {
     expect(wrapper.text()).toContain('Create your first plan to start tracking expenses')
   })
 
-  it('displays the calendar icon', () => {
+  it('displays the plan illustration', () => {
     const wrapper = createWrapper()
-    const icon = wrapper.findComponent({ name: 'QIcon' })
-    expect(icon.exists()).toBe(true)
-    expect(icon.props('name')).toBe('eva-calendar-outline')
+    const illustration = wrapper.findComponent(BrandIllustration)
+    expect(illustration.exists()).toBe(true)
+    expect(illustration.props('name')).toBe('plan')
+    expect(wrapper.find('svg.brand-illustration').exists()).toBe(true)
   })
 
   it('renders a button to create plan', () => {

--- a/src/components/dashboard/EmptyTemplatesState.test.ts
+++ b/src/components/dashboard/EmptyTemplatesState.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { describe, it, expect } from 'vitest'
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest'
 import EmptyTemplatesState from './EmptyTemplatesState.vue'
+import BrandIllustration from 'src/components/shared/BrandIllustration.vue'
 
 installQuasarPlugin()
 
@@ -30,11 +31,12 @@ describe('EmptyTemplatesState', () => {
     expect(wrapper.text()).toContain('Create templates to quickly plan your budgets')
   })
 
-  it('displays the bookmark icon', () => {
+  it('displays the template illustration', () => {
     const wrapper = createWrapper()
-    const icon = wrapper.findComponent({ name: 'QIcon' })
-    expect(icon.exists()).toBe(true)
-    expect(icon.props('name')).toBe('eva-bookmark-outline')
+    const illustration = wrapper.findComponent(BrandIllustration)
+    expect(illustration.exists()).toBe(true)
+    expect(illustration.props('name')).toBe('template')
+    expect(wrapper.find('svg.brand-illustration').exists()).toBe(true)
   })
 
   it('renders a button to create template', () => {

--- a/src/components/dashboard/EmptyTemplatesState.vue
+++ b/src/components/dashboard/EmptyTemplatesState.vue
@@ -5,16 +5,12 @@
     class="text-center"
   >
     <q-card-section>
-      <q-icon
-        name="eva-bookmark-outline"
-        size="64px"
-        color="grey-5"
-        class="q-mb-md"
+      <BrandIllustration
+        name="template"
+        class="q-mb-sm"
       />
-      <div class="text-h6 text-grey-7 q-mb-sm">No Templates Yet</div>
-      <div class="text-body2 text-grey-6 q-mb-md">
-        Create templates to quickly plan your budgets
-      </div>
+      <div class="text-h6 q-mb-sm">No Templates Yet</div>
+      <div class="text-body2 text-muted q-mb-md">Create templates to quickly plan your budgets</div>
       <q-btn
         color="primary"
         label="Create Template"
@@ -27,3 +23,7 @@
     </q-card-section>
   </q-card>
 </template>
+
+<script setup lang="ts">
+import BrandIllustration from 'src/components/shared/BrandIllustration.vue'
+</script>

--- a/src/components/dashboard/RecentActivityCard.vue
+++ b/src/components/dashboard/RecentActivityCard.vue
@@ -1,0 +1,135 @@
+<template>
+  <q-card
+    v-if="isLoading || recentExpenses.length > 0"
+    :bordered="$q.dark.isActive"
+    class="shadow-1"
+  >
+    <q-card-section class="q-pb-none">
+      <div class="row items-center justify-between">
+        <h2 class="text-subtitle1 text-weight-medium q-my-none">Recent activity</h2>
+        <q-btn
+          flat
+          no-caps
+          dense
+          color="primary"
+          label="View all"
+          to="/expenses"
+        />
+      </div>
+    </q-card-section>
+
+    <q-card-section
+      v-if="isLoading"
+      class="q-pt-sm"
+    >
+      <div
+        v-for="n in 3"
+        :key="n"
+        class="row items-center q-py-sm"
+      >
+        <q-skeleton
+          type="QAvatar"
+          size="32px"
+          class="q-mr-md"
+        />
+        <div class="col">
+          <q-skeleton
+            type="text"
+            width="50%"
+          />
+          <q-skeleton
+            type="text"
+            width="30%"
+          />
+        </div>
+      </div>
+    </q-card-section>
+
+    <q-list
+      v-else
+      separator
+      class="q-pb-sm"
+    >
+      <q-item
+        v-for="expense in recentExpenses"
+        :key="expense.id"
+        clickable
+        @click="openExpensePlan(expense)"
+      >
+        <q-item-section
+          avatar
+          class="min-w-auto"
+        >
+          <CategoryIcon
+            :color="expense.categories?.color || '#666'"
+            :icon="expense.categories?.icon || 'eva-folder-outline'"
+            size="sm"
+          />
+        </q-item-section>
+
+        <q-item-section>
+          <q-item-label class="text-weight-medium">{{ expense.name }}</q-item-label>
+          <q-item-label caption>
+            <template v-if="expense.plans?.name">{{ expense.plans.name }} • </template>
+            {{ formatDate(expense.expense_date) }}
+          </q-item-label>
+        </q-item-section>
+
+        <q-item-section side>
+          <q-item-label class="text-weight-bold text-amount">
+            {{ formatAmount(expense) }}
+          </q-item-label>
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useQuasar } from 'quasar'
+import { useRouter } from 'vue-router'
+import CategoryIcon from 'src/components/categories/CategoryIcon.vue'
+import { useRecentExpensesQuery } from 'src/queries/expenses'
+import { useUserStore } from 'src/stores/user'
+import { usePreferencesStore } from 'src/stores/preferences'
+import { formatCurrency, formatCurrencyPrivate, type CurrencyCode } from 'src/utils/currency'
+import { formatDate } from 'src/utils/date'
+import type { ExpenseWithCategoryAndPlan } from 'src/api'
+
+const MAX_ITEMS = 4
+
+const $q = useQuasar()
+const router = useRouter()
+const userStore = useUserStore()
+const preferencesStore = usePreferencesStore()
+
+const userId = computed(() => userStore.userProfile?.id)
+
+const { expenses, isPending } = useRecentExpensesQuery(userId, 20)
+
+const isLoading = computed(() => isPending.value)
+const recentExpenses = computed(() => expenses.value.slice(0, MAX_ITEMS))
+
+function expenseCurrency(expense: ExpenseWithCategoryAndPlan): CurrencyCode {
+  return (expense.plans?.currency ?? preferencesStore.currency) as CurrencyCode
+}
+
+function formatAmount(expense: ExpenseWithCategoryAndPlan): string {
+  const currency = expenseCurrency(expense)
+
+  if (preferencesStore.isPrivacyModeEnabled) {
+    return formatCurrencyPrivate(currency)
+  }
+
+  return formatCurrency(expense.amount, currency)
+}
+
+function openExpensePlan(expense: ExpenseWithCategoryAndPlan) {
+  if (expense.plans?.id) {
+    void router.push({ name: 'plan', params: { id: expense.plans.id } })
+  } else {
+    void router.push('/expenses')
+  }
+}
+</script>

--- a/src/components/dashboard/TopCategoriesCard.vue
+++ b/src/components/dashboard/TopCategoriesCard.vue
@@ -1,0 +1,114 @@
+<template>
+  <q-card
+    v-if="topCategories.length > 0"
+    :bordered="$q.dark.isActive"
+    class="shadow-1"
+  >
+    <q-card-section>
+      <div class="row items-center justify-between q-mb-sm">
+        <h2 class="text-subtitle1 text-weight-medium q-my-none">Top categories</h2>
+      </div>
+
+      <div
+        v-for="(category, index) in topCategories"
+        :key="category.categoryId"
+        class="top-category-row"
+        :class="{ 'q-mt-md': index > 0 }"
+      >
+        <div class="row items-center justify-between no-wrap">
+          <div class="text-body2 ellipsis col q-pr-sm">{{ category.categoryName }}</div>
+          <div class="text-body2 text-weight-medium text-amount row items-center no-wrap">
+            <q-icon
+              v-if="category.remainingAmount < 0"
+              name="eva-alert-triangle-outline"
+              size="14px"
+              class="text-warning q-mr-xs"
+            />
+            {{ formatAmount(category.actualAmount) }}
+          </div>
+        </div>
+        <q-linear-progress
+          :value="categoryProgress(category)"
+          :style="{ color: chartColor(index) }"
+          :aria-label="`${category.categoryName}: ${formatAmount(category.actualAmount)} of ${formatAmount(category.plannedAmount)}`"
+          size="6px"
+          class="top-category-row__bar q-mt-xs"
+        />
+      </div>
+
+      <q-btn
+        flat
+        no-caps
+        dense
+        color="primary"
+        class="q-mt-md"
+        icon-right="eva-arrow-forward-outline"
+        label="See all categories"
+        @click="emit('click', plan.id)"
+      />
+    </q-card-section>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useQuasar } from 'quasar'
+import { usePlanDetailQuery } from 'src/queries/plans'
+import { useUserStore } from 'src/stores/user'
+import { usePreferencesStore } from 'src/stores/preferences'
+import { usePlanOverview } from 'src/composables/usePlanOverview'
+import { formatCurrency, formatCurrencyPrivate, type CurrencyCode } from 'src/utils/currency'
+import type { PlanWithPermission } from 'src/api'
+import type { CategoryBudget } from 'src/types'
+
+const emit = defineEmits<{
+  click: [planId: string]
+}>()
+
+const props = defineProps<{
+  plan: PlanWithPermission
+}>()
+
+const $q = useQuasar()
+const userStore = useUserStore()
+const userId = computed(() => userStore.userProfile?.id)
+const preferencesStore = usePreferencesStore()
+
+const planId = computed(() => props.plan.id)
+const planDetailQuery = usePlanDetailQuery(planId, userId)
+const planWithItems = computed(() => planDetailQuery.data.value ?? null)
+
+const { categoryBudgets } = usePlanOverview(planId, planWithItems)
+
+const topCategories = computed(() =>
+  [...categoryBudgets.value].sort((a, b) => b.actualAmount - a.actualAmount).slice(0, 3),
+)
+
+// Category accents intentionally avoid the over/under-budget green/orange/red semantics
+const CHART_COLORS = ['hsl(var(--chart-1))', 'hsl(var(--chart-2))', 'hsl(var(--chart-3))']
+
+function chartColor(index: number): string {
+  return CHART_COLORS[index % CHART_COLORS.length] as string
+}
+
+function categoryProgress(category: CategoryBudget): number {
+  if (category.plannedAmount <= 0) return 0
+  return Math.min(category.actualAmount / category.plannedAmount, 1)
+}
+
+function formatAmount(amount: number | null | undefined): string {
+  const currency = props.plan.currency as CurrencyCode
+
+  if (preferencesStore.isPrivacyModeEnabled) {
+    return formatCurrencyPrivate(currency)
+  }
+
+  return formatCurrency(amount, currency)
+}
+</script>
+
+<style lang="scss" scoped>
+.top-category-row__bar {
+  border-radius: var(--radius-full);
+}
+</style>

--- a/src/components/expenses/BudgetImpactCard.test.ts
+++ b/src/components/expenses/BudgetImpactCard.test.ts
@@ -104,7 +104,7 @@ describe('BudgetImpactCard', () => {
         },
       })
 
-      expect(wrapper.text()).toContain('$20.00 over')
+      expect(wrapper.text()).toContain('−$20.00 over')
     })
 
     it('should apply correct color classes for current budget state', () => {
@@ -183,7 +183,7 @@ describe('BudgetImpactCard', () => {
         },
       })
 
-      expect(wrapper.text()).toContain('$10.00 over')
+      expect(wrapper.text()).toContain('−$10.00 over')
     })
 
     it('should display checkmark icon when within budget', () => {
@@ -310,8 +310,8 @@ describe('BudgetImpactCard', () => {
       })
 
       const card = wrapper.findComponent({ name: 'QCard' })
-      expect(card.classes()).not.toContain('bg-orange-1')
-      expect(card.classes()).not.toContain('bg-red-1')
+      expect(card.classes()).not.toContain('bg-warning-soft')
+      expect(card.classes()).not.toContain('bg-destructive-soft')
     })
 
     it('should have orange background when 90-100% of budget', () => {
@@ -326,7 +326,7 @@ describe('BudgetImpactCard', () => {
       })
 
       const card = wrapper.findComponent({ name: 'QCard' })
-      expect(card.classes()).toContain('bg-orange-1')
+      expect(card.classes()).toContain('bg-warning-soft')
     })
 
     it('should have red background when over 100% of budget', () => {
@@ -341,7 +341,7 @@ describe('BudgetImpactCard', () => {
       })
 
       const card = wrapper.findComponent({ name: 'QCard' })
-      expect(card.classes()).toContain('bg-red-1')
+      expect(card.classes()).toContain('bg-destructive-soft')
     })
 
     it('should use current budget percentage for background when no amount', () => {
@@ -362,7 +362,7 @@ describe('BudgetImpactCard', () => {
       })
 
       const card = wrapper.findComponent({ name: 'QCard' })
-      expect(card.classes()).toContain('bg-red-1')
+      expect(card.classes()).toContain('bg-destructive-soft')
     })
   })
 

--- a/src/components/expenses/BudgetImpactCard.vue
+++ b/src/components/expenses/BudgetImpactCard.vue
@@ -10,7 +10,7 @@
       <!-- Empty State: No category selected -->
       <div
         v-if="!categoryId"
-        class="text-center q-py-md text-grey-6 text-body2"
+        class="text-center q-py-md text-muted text-body2"
       >
         <q-icon
           name="eva-info-outline"
@@ -34,7 +34,7 @@
           <span>{{ Math.round(currentBudgetPercentage) }}% used</span>
           <span
             v-if="currency && categoryOption"
-            class="text-weight-medium"
+            class="text-weight-medium text-amount"
           >
             {{ formatCurrency(categoryOption.actualAmount, currency) }}
             /
@@ -46,19 +46,19 @@
 
         <div class="column">
           <div class="row justify-between text-caption">
-            <span class="text-grey-7">Remaining:</span>
+            <span class="text-muted">Remaining:</span>
             <span
               v-if="categoryOption"
               :class="currentBudgetRemainingColorClass"
-              class="text-weight-bold"
+              class="text-weight-bold text-amount"
             >
-              {{ formatCurrency(Math.abs(categoryOption.remainingAmount), currency ?? 'USD') }}
+              {{ formatCurrencyWithSign(categoryOption.remainingAmount, currency ?? 'USD') }}
               {{ categoryOption.remainingAmount >= 0 ? 'left' : 'over' }}
             </span>
           </div>
         </div>
 
-        <div class="text-center q-mt-md text-grey-6 text-caption">
+        <div class="text-center q-mt-md text-caption">
           Enter an amount to see the impact on this budget
         </div>
       </div>
@@ -77,7 +77,7 @@
           <span>{{ Math.round(budgetPercentageAfter) }}% used</span>
           <span
             v-if="currency"
-            class="text-weight-medium"
+            class="text-weight-medium text-amount"
           >
             {{ formatCurrency(newSpentAmount, currency) }}
             /
@@ -89,8 +89,8 @@
 
         <div class="column">
           <div class="row justify-between text-caption">
-            <span class="text-grey-7">Current:</span>
-            <span>
+            <span class="text-muted">Current:</span>
+            <span class="text-amount">
               {{ formatCurrency(categoryOption.actualAmount, currency ?? 'USD') }}
               /
               {{ formatCurrency(categoryOption.plannedAmount, currency ?? 'USD') }}
@@ -98,22 +98,22 @@
           </div>
 
           <div class="row justify-between text-caption">
-            <span class="text-grey-7">Adding:</span>
-            <span class="text-weight-medium">
+            <span class="text-muted">Adding:</span>
+            <span class="text-weight-medium text-amount">
               +{{ formatCurrency(amount, currency ?? 'USD') }}
             </span>
           </div>
 
           <div class="row justify-between text-caption">
-            <span class="text-grey-7">After:</span>
+            <span class="text-muted">After:</span>
             <span
               :class="budgetStatusTextClass"
-              class="text-weight-bold"
+              class="text-weight-bold text-amount"
             >
               {{ formatCurrency(newSpentAmount, currency ?? 'USD') }}
               /
               {{ formatCurrency(categoryOption.plannedAmount, currency ?? 'USD') }}
-              ({{ formatCurrency(Math.abs(newRemainingAmount), currency ?? 'USD') }}
+              ({{ formatCurrencyWithSign(newRemainingAmount, currency ?? 'USD') }}
               {{ newRemainingAmount >= 0 ? 'left' : 'over' }})
               <q-icon
                 :name="budgetStatusIcon"
@@ -130,7 +130,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { formatCurrency, type CurrencyCode } from 'src/utils/currency'
+import { formatCurrency, formatCurrencyWithSign, type CurrencyCode } from 'src/utils/currency'
 import { getBudgetProgressColor, getBudgetRemainingColorClass } from 'src/utils/budget'
 
 interface CategoryOption {
@@ -202,8 +202,8 @@ const budgetImpactCardClass = computed(() => {
     props.amount && props.amount > 0 ? budgetPercentageAfter.value : currentBudgetPercentage.value
 
   if (percentage < 90) return ''
-  if (percentage < 100) return 'bg-orange-1'
+  if (percentage < 100) return 'bg-warning-soft'
   if (percentage === 100) return ''
-  return 'bg-red-1'
+  return 'bg-destructive-soft'
 })
 </script>

--- a/src/components/expenses/EmptyExpensesState.vue
+++ b/src/components/expenses/EmptyExpensesState.vue
@@ -2,25 +2,25 @@
   <q-card
     flat
     bordered
-    class="text-center"
+    class="text-center q-py-lg"
   >
     <q-card-section>
       <BrandIllustration
-        name="plan"
+        name="receipt"
         class="q-mb-sm"
       />
-      <div class="text-h6 q-mb-sm">No Active Plans</div>
+      <div class="text-h6 q-mb-sm">No expenses yet</div>
       <div class="text-body2 text-muted q-mb-md">
-        Create your first plan to start tracking expenses
+        Log your first expense and it will show up here
       </div>
       <q-btn
         color="primary"
-        label="Create Plan"
+        label="Add Your First Expense"
         icon="eva-plus-outline"
         unelevated
         dense
         no-caps
-        to="/plans"
+        @click="emit('add-expense')"
       />
     </q-card-section>
   </q-card>
@@ -28,4 +28,8 @@
 
 <script setup lang="ts">
 import BrandIllustration from 'src/components/shared/BrandIllustration.vue'
+
+const emit = defineEmits<{
+  'add-expense': []
+}>()
 </script>

--- a/src/components/expenses/ExpenseAmountCurrencyFields.vue
+++ b/src/components/expenses/ExpenseAmountCurrencyFields.vue
@@ -50,7 +50,7 @@
   >
     <div
       v-if="isConverting"
-      class="text-caption text-grey-7"
+      class="text-caption"
     >
       <q-spinner
         size="12px"
@@ -78,9 +78,9 @@
         size="14px"
         class="q-mr-xs text-primary"
       />
-      <span class="text-grey-7">Converted amount:</span>
-      <span class="text-weight-bold q-ml-xs">{{ convertedAmountDisplay }}</span>
-      <span class="text-grey-6 q-ml-xs"> (Rate: {{ conversionResult.rate.toFixed(4) }}) </span>
+      <span class="text-muted">Converted amount:</span>
+      <span class="text-weight-bold q-ml-xs text-amount">{{ convertedAmountDisplay }}</span>
+      <span class="text-muted q-ml-xs"> (Rate: {{ conversionResult.rate.toFixed(4) }}) </span>
     </div>
   </div>
 </template>

--- a/src/components/expenses/ExpenseListItem.vue
+++ b/src/components/expenses/ExpenseListItem.vue
@@ -47,13 +47,13 @@
         class="items-end"
       >
         <div class="column items-end">
-          <q-item-label class="text-weight-bold text-primary">
+          <q-item-label class="text-weight-bold text-primary text-amount">
             {{ formatCurrency(expense.amount, currency) }}
           </q-item-label>
           <q-item-label
             v-if="expense.original_amount && expense.original_currency"
             caption
-            class="text-caption text-grey-6"
+            class="text-caption text-amount"
           >
             {{ formatCurrency(expense.original_amount, expense.original_currency as CurrencyCode) }}
           </q-item-label>
@@ -98,13 +98,13 @@
     >
       <div class="row items-center q-gutter-sm">
         <div class="column items-end">
-          <q-item-label class="text-weight-bold text-primary">
+          <q-item-label class="text-weight-bold text-primary text-amount">
             {{ formatCurrency(expense.amount, currency) }}
           </q-item-label>
           <q-item-label
             v-if="expense.original_amount && expense.original_currency"
             caption
-            class="text-caption text-grey-6"
+            class="text-caption text-amount"
           >
             {{ formatCurrency(expense.original_amount, expense.original_currency as CurrencyCode) }}
           </q-item-label>

--- a/src/components/expenses/ExpensePhotoAnalysisSection.vue
+++ b/src/components/expenses/ExpensePhotoAnalysisSection.vue
@@ -14,7 +14,7 @@
             Analyzed
           </q-chip>
         </div>
-        <div class="text-caption text-grey-7">Prefill details from a receipt</div>
+        <div class="text-caption">Prefill details from a receipt</div>
       </div>
 
       <q-btn
@@ -88,7 +88,7 @@
 
         <q-banner
           v-if="photoAnalysis.hasError.value"
-          class="bg-orange-1 text-orange-9 q-mt-sm"
+          class="bg-warning-soft text-warning-strong q-mt-sm"
           dense
         >
           <template #avatar>
@@ -100,7 +100,7 @@
           {{ photoAnalysis.errorMessage.value }}
         </q-banner>
 
-        <p class="text-caption text-grey-7 q-mt-sm q-mb-none text-center">
+        <p class="text-caption q-mt-sm q-mb-none text-center">
           Supports JPEG, PNG, WebP, HEIC • Max 5MB
         </p>
       </div>
@@ -108,7 +108,7 @@
 
     <div class="row items-center q-mt-md">
       <q-separator class="col" />
-      <span class="q-mx-md text-grey-6 text-caption text-weight-medium"> OR ENTER MANUALLY </span>
+      <span class="q-mx-md text-caption text-weight-medium"> OR ENTER MANUALLY </span>
       <q-separator class="col" />
     </div>
   </div>

--- a/src/components/expenses/QuickSelectPanel.vue
+++ b/src/components/expenses/QuickSelectPanel.vue
@@ -53,7 +53,7 @@
             class="q-mb-md"
           >
             <q-card-section class="q-pa-sm">
-              <div class="text-body2 text-grey-7 q-mb-xs">Selected Plan</div>
+              <div class="text-body2 text-muted q-mb-xs">Selected Plan</div>
               <div class="text-subtitle1 text-weight-medium">
                 {{ selectedPlan?.name }}
               </div>
@@ -67,7 +67,7 @@
             class="q-mb-md"
           >
             <q-card-section class="q-pa-sm">
-              <div class="text-body2 text-grey-7 q-mb-xs">
+              <div class="text-body2 text-muted q-mb-xs">
                 Selected Items ({{ selectedPlanItems.length }})
               </div>
               <q-list dense>

--- a/src/components/notifications/NotificationInbox.vue
+++ b/src/components/notifications/NotificationInbox.vue
@@ -37,7 +37,7 @@
         <q-icon
           name="eva-bell-off-outline"
           size="28px"
-          class="text-grey-5 q-mb-sm"
+          class="text-faint q-mb-sm"
         />
         <div class="text-subtitle2 q-mb-xs">No notifications yet</div>
         <div class="notifications-inbox__empty-copy text-muted">

--- a/src/components/plans/CategoryBudgetCard.test.ts
+++ b/src/components/plans/CategoryBudgetCard.test.ts
@@ -10,6 +10,10 @@ installQuasarPlugin()
 
 vi.mock('src/utils/currency', () => ({
   formatCurrency: vi.fn((amount: number, currency: string) => `${currency} ${amount.toFixed(2)}`),
+  formatCurrencyWithSign: vi.fn(
+    (amount: number, currency: string) =>
+      `${amount < 0 ? '−' : ''}${currency} ${Math.abs(amount).toFixed(2)}`,
+  ),
 }))
 
 vi.mock('src/utils/budget', () => ({

--- a/src/components/plans/CategoryBudgetCard.vue
+++ b/src/components/plans/CategoryBudgetCard.vue
@@ -43,7 +43,7 @@
               class="q-ml-xs flex-shrink-0"
             />
           </div>
-          <span class="text-caption text-grey-6 q-mt-none">
+          <span class="text-caption q-mt-none">
             {{ category.expenseCount }} {{ category.expenseCount === 1 ? 'expense' : 'expenses' }}
           </span>
         </div>
@@ -56,7 +56,7 @@
           size="48px"
           :thickness="0.15"
           :color="progressColor"
-          track-color="grey-4"
+          :track-color="$q.dark.isActive ? 'grey-9' : 'grey-2'"
           class="q-ml-md flex-shrink-0"
         >
           <span class="text-caption text-weight-bold">{{ Math.round(percentageUsed) }}%</span>
@@ -75,7 +75,7 @@
             size="52px"
             :thickness="0.17"
             :color="progressColor"
-            track-color="grey-4"
+            :track-color="$q.dark.isActive ? 'grey-9' : 'grey-2'"
             class="text-weight-bold q-mr-md"
           >
             <span class="text-caption text-weight-bold">{{ Math.round(percentageUsed) }}%</span>
@@ -84,8 +84,8 @@
           <!-- Details Section -->
           <div class="col">
             <div class="row justify-between text-caption">
-              <span class="text-grey-6">Spent</span>
-              <span class="text-weight-bold">
+              <span class="text-muted">Spent</span>
+              <span class="text-weight-bold text-amount">
                 {{ formatCurrency(category.actualAmount, currency) }}
               </span>
             </div>
@@ -100,12 +100,14 @@
             />
 
             <div class="row justify-between text-caption">
-              <span class="text-grey-6">Budget</span>
-              <span>{{ formatCurrency(category.plannedAmount, currency) }}</span>
+              <span class="text-muted">Budget</span>
+              <span class="text-amount">{{
+                formatCurrency(category.plannedAmount, currency)
+              }}</span>
             </div>
 
             <div class="row justify-between text-caption">
-              <span class="text-grey-6">{{
+              <span class="text-muted">{{
                 category.remainingAmount > 0
                   ? 'Still to pay'
                   : category.remainingAmount < 0
@@ -113,10 +115,10 @@
                     : 'Still to pay'
               }}</span>
               <span
-                class="text-weight-bold"
+                class="text-weight-bold text-amount"
                 :class="remainingAmountColor"
               >
-                {{ formatCurrency(Math.abs(category.remainingAmount), currency) }}
+                {{ formatCurrencyWithSign(category.remainingAmount, currency) }}
               </span>
             </div>
           </div>
@@ -129,7 +131,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import CategoryIcon from 'src/components/categories/CategoryIcon.vue'
-import { formatCurrency, type CurrencyCode } from 'src/utils/currency'
+import { formatCurrency, formatCurrencyWithSign, type CurrencyCode } from 'src/utils/currency'
 import { getBudgetProgressColor, getBudgetRemainingColorClass } from 'src/utils/budget'
 import type { CategoryBudget } from 'src/types'
 

--- a/src/components/plans/CategoryBudgetListItem.vue
+++ b/src/components/plans/CategoryBudgetListItem.vue
@@ -31,12 +31,12 @@
         </div>
         <div class="text-right q-pl-sm flex-shrink-0">
           <span
-            class="text-weight-bold text-body2"
+            class="text-weight-bold text-body2 text-amount"
             :class="remainingAmountColor"
           >
-            {{ formatCurrency(Math.abs(category.remainingAmount), currency) }}
+            {{ formatCurrencyWithSign(category.remainingAmount, currency) }}
           </span>
-          <span class="text-caption text-grey-6 q-ml-xs">
+          <span class="text-caption q-ml-xs">
             {{ category.remainingAmount >= 0 ? 'left' : 'over' }}
           </span>
         </div>
@@ -45,13 +45,15 @@
       <!-- Middle row: Spent of Planned & Percentage -->
       <div class="row justify-between items-center text-caption q-mb-xs">
         <div class="ellipsis">
-          <span class="text-weight-medium">{{
+          <span class="text-weight-medium text-amount">{{
             formatCurrency(category.actualAmount, currency)
           }}</span>
-          <span class="text-grey-6 q-mx-xs">of</span>
-          <span class="text-grey-6">{{ formatCurrency(category.plannedAmount, currency) }}</span>
+          <span class="text-muted q-mx-xs">of</span>
+          <span class="text-muted text-amount">{{
+            formatCurrency(category.plannedAmount, currency)
+          }}</span>
         </div>
-        <div class="text-weight-medium text-grey-6 flex-shrink-0 q-pl-sm">
+        <div class="text-weight-medium text-muted flex-shrink-0 q-pl-sm">
           {{ roundedPercentage }}%
         </div>
       </div>
@@ -71,7 +73,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import CategoryIcon from 'src/components/categories/CategoryIcon.vue'
-import { formatCurrency, type CurrencyCode } from 'src/utils/currency'
+import { formatCurrency, formatCurrencyWithSign, type CurrencyCode } from 'src/utils/currency'
 import { getBudgetProgressColor, getBudgetRemainingColorClass } from 'src/utils/budget'
 import type { CategoryBudget } from 'src/types'
 

--- a/src/components/plans/CategoryExpensesDialog.vue
+++ b/src/components/plans/CategoryExpensesDialog.vue
@@ -25,7 +25,7 @@
           <div class="col-4">
             <div class="text-center">
               <div class="text-caption text-caption-secondary">Budget</div>
-              <div class="text-body1 text-weight-bold">
+              <div class="text-body1 text-weight-bold text-amount">
                 {{ formatCurrency(category?.plannedAmount || 0, currency) }}
               </div>
             </div>
@@ -33,7 +33,7 @@
           <div class="col-4">
             <div class="text-center">
               <div class="text-caption text-caption-secondary">Spent</div>
-              <div class="text-body1 text-weight-bold text-info">
+              <div class="text-body1 text-weight-bold text-info text-amount">
                 {{ formatCurrency(category?.actualAmount || 0, currency) }}
               </div>
             </div>
@@ -44,7 +44,7 @@
                 {{ (category?.remainingAmount || 0) >= 0 ? 'Still to pay' : 'Over' }}
               </div>
               <div
-                class="text-body1 text-weight-bold"
+                class="text-body1 text-weight-bold text-amount"
                 :class="remainingColorClass"
               >
                 {{ formatCurrency(Math.abs(category?.remainingAmount || 0), currency) }}
@@ -148,11 +148,14 @@
               </q-item-section>
 
               <q-item-section>
-                <q-item-label :class="item.is_completed ? 'text-grey-6' : 'text-weight-medium'">
+                <q-item-label :class="item.is_completed ? 'text-muted' : 'text-weight-medium'">
                   {{ item.name }}
                 </q-item-label>
                 <q-item-label caption>
-                  <span :class="item.is_completed ? 'text-grey-5' : ''">
+                  <span
+                    class="text-amount"
+                    :class="item.is_completed ? 'text-faint' : ''"
+                  >
                     {{ formatCurrency(item.amount, currency) }}
                   </span>
                 </q-item-label>
@@ -177,7 +180,7 @@
                 v-for="item in nonFixedPlanItems"
                 :key="item.id"
                 dense
-                class="text-grey-6"
+                class="text-muted"
               >
                 <q-item-section
                   class="q-pr-sm category-dialog-icon-section"
@@ -195,7 +198,7 @@
                     {{ item.name }}
                   </q-item-label>
                   <q-item-label caption>
-                    <span class="text-caption-secondary">
+                    <span class="text-caption-secondary text-amount">
                       {{ formatCurrency(item.amount, currency) }}
                     </span>
                   </q-item-label>

--- a/src/components/plans/PlanCard.vue
+++ b/src/components/plans/PlanCard.vue
@@ -37,7 +37,7 @@
               round
               size="sm"
               icon="eva-more-vertical-outline"
-              class="text-grey-7"
+              class="text-muted"
               :aria-label="menuButtonLabel"
               aria-haspopup="menu"
               @click.stop
@@ -57,7 +57,7 @@
         <div class="q-mt-lg">
           <div class="row items-center justify-between">
             <div class="col">
-              <div class="text-subtitle1 text-weight-bold text-primary">
+              <div class="text-subtitle1 text-weight-bold text-primary text-amount">
                 {{ formatAmount(plan.total) }}
               </div>
             </div>
@@ -76,7 +76,7 @@
 
           <div class="row items-center">
             <div class="col">
-              <div class="text-caption text-grey-6">
+              <div class="text-caption">
                 {{ formatDateRange(plan.start_date, plan.end_date) }}
               </div>
             </div>

--- a/src/components/plans/PlanEditTab.vue
+++ b/src/components/plans/PlanEditTab.vue
@@ -31,7 +31,7 @@
           :all-expanded="allExpanded"
           :has-duplicates="hasDuplicates"
           duplicate-banner-position="bottom"
-          :duplicate-banner-class="$q.dark.isActive ? 'bg-red-9 text-red-3' : 'bg-red-1 text-red-8'"
+          duplicate-banner-class="bg-destructive-soft text-destructive-strong"
           :bordered="false"
           :padding="false"
           transparent
@@ -74,11 +74,16 @@
             />
             <h3 class="text-h6 q-my-none">Total Amount</h3>
           </div>
-          <div :class="['text-primary text-weight-bold', $q.screen.lt.md ? 'text-h6' : 'text-h5']">
+          <div
+            :class="[
+              'text-primary text-weight-bold text-amount',
+              $q.screen.lt.md ? 'text-h6' : 'text-h5',
+            ]"
+          >
             {{ formattedTotal }}
           </div>
         </div>
-        <div class="text-caption text-grey-6">
+        <div class="text-caption">
           Total across {{ categoryGroups.length }}
           {{ categoryGroups.length === 1 ? 'category' : 'categories' }}
         </div>

--- a/src/components/plans/PlanFormSection.vue
+++ b/src/components/plans/PlanFormSection.vue
@@ -37,9 +37,7 @@
             :all-expanded="allExpanded"
             :has-duplicates="hasDuplicates"
             duplicate-banner-position="bottom"
-            :duplicate-banner-class="
-              $q.dark.isActive ? 'bg-red-9 text-red-3' : 'bg-red-1 text-red-8'
-            "
+            duplicate-banner-class="bg-destructive-soft text-destructive-strong"
             empty-message="Select a template to load plan items"
             :bordered="false"
             :padding="false"
@@ -81,12 +79,15 @@
               <h3 class="text-h6 q-my-none">Total Amount</h3>
             </div>
             <div
-              :class="['text-primary text-weight-bold', $q.screen.lt.md ? 'text-h6' : 'text-h5']"
+              :class="[
+                'text-primary text-weight-bold text-amount',
+                $q.screen.lt.md ? 'text-h6' : 'text-h5',
+              ]"
             >
               {{ formattedTotal }}
             </div>
           </div>
-          <div class="text-caption text-grey-6">
+          <div class="text-caption">
             Total across {{ categoryGroups.length }}
             {{ categoryGroups.length === 1 ? 'category' : 'categories' }}
           </div>

--- a/src/components/plans/PlanItemsTrackingTab.vue
+++ b/src/components/plans/PlanItemsTrackingTab.vue
@@ -123,10 +123,10 @@
         <q-icon
           name="eva-checkmark-square-2-outline"
           size="64px"
-          class="text-grey-4 q-mb-md"
+          class="text-faint q-mb-md"
         />
-        <div class="text-h6 text-grey-6 q-mb-sm">No Items to Track</div>
-        <div class="text-body2 text-grey-6">This plan doesn't have any items to track yet.</div>
+        <div class="text-h6 text-muted q-mb-sm">No Items to Track</div>
+        <div class="text-body2 text-muted">This plan doesn't have any items to track yet.</div>
       </q-card-section>
 
       <!-- Items by Category -->
@@ -177,7 +177,7 @@
                   </div>
                   <div
                     v-if="!$q.screen.lt.sm"
-                    class="text-caption text-grey-6"
+                    class="text-caption"
                   >
                     completed
                   </div>
@@ -219,7 +219,6 @@
                   <q-item-label
                     header
                     class="text-caption q-py-xs q-px-sm"
-                    :class="$q.dark.isActive ? 'text-grey-5' : 'text-grey-6'"
                   >
                     For Reference
                   </q-item-label>
@@ -237,7 +236,7 @@
                       <q-icon
                         name="eva-bookmark-outline"
                         size="24px"
-                        :class="$q.dark.isActive ? 'text-grey-6' : 'text-grey-5'"
+                        class="text-faint"
                       />
                     </template>
                   </CompactDisplayItemRow>

--- a/src/components/plans/PlanOverviewTab.vue
+++ b/src/components/plans/PlanOverviewTab.vue
@@ -26,7 +26,7 @@
 
         <div
           v-if="categoryBudgets.length === 0"
-          class="text-center text-grey-6 q-py-lg"
+          class="text-center text-muted q-py-lg"
         >
           <q-icon
             name="eva-folder-outline"

--- a/src/components/plans/PlanSummaryCard.test.ts
+++ b/src/components/plans/PlanSummaryCard.test.ts
@@ -10,6 +10,10 @@ installQuasarPlugin()
 
 vi.mock('src/utils/currency', () => ({
   formatCurrency: vi.fn((amount: number, currency: string) => `${currency} ${amount.toFixed(2)}`),
+  formatCurrencyWithSign: vi.fn(
+    (amount: number, currency: string) =>
+      `${amount < 0 ? '−' : ''}${currency} ${Math.abs(amount).toFixed(2)}`,
+  ),
 }))
 
 vi.mock('src/utils/plans', () => ({

--- a/src/components/plans/PlanSummaryCard.vue
+++ b/src/components/plans/PlanSummaryCard.vue
@@ -4,7 +4,7 @@
       <div class="row items-center justify-between q-mb-md">
         <div>
           <h6 class="text-h6 q-my-none">{{ plan?.name }}</h6>
-          <div class="text-caption text-grey-6">
+          <div class="text-caption">
             {{ formatDateRange(plan?.start_date || '', plan?.end_date || '') }}
           </div>
         </div>
@@ -26,30 +26,35 @@
         :class="$q.screen.lt.md ? 'q-col-gutter-xs' : 'q-col-gutter-md'"
       >
         <div class="col">
-          <div class="text-caption text-grey-6">Planned Budget</div>
+          <div class="text-caption">Planned Budget</div>
           <div
-            class="text-weight-bold"
+            class="text-weight-bold text-amount"
             :class="$q.screen.lt.md ? 'text-subtitle2' : 'text-h6'"
           >
             {{ formatCurrency(totalBudget, currency) }}
           </div>
         </div>
         <div class="col">
-          <div class="text-caption text-grey-6">Total Spent</div>
+          <div class="text-caption">Total Spent</div>
           <div
-            class="text-weight-bold text-info"
+            class="text-weight-bold text-info text-amount"
             :class="$q.screen.lt.md ? 'text-subtitle2' : 'text-h6'"
           >
             {{ formatCurrency(totalSpent, currency) }}
           </div>
         </div>
         <div class="col">
-          <div class="text-caption text-grey-6">{{ remaining >= 0 ? 'Still to pay' : 'Over' }}</div>
+          <div class="text-caption">{{ remaining >= 0 ? 'Still to pay' : 'Over' }}</div>
           <div
-            class="text-weight-bold"
+            class="text-weight-bold text-amount"
             :class="[remainingColorClass, $q.screen.lt.md ? 'text-subtitle2' : 'text-h6']"
           >
-            {{ formatCurrency(Math.abs(remaining), currency) }}
+            <q-icon
+              v-if="remaining < 0"
+              name="eva-alert-triangle-outline"
+              size="14px"
+            />
+            {{ formatCurrencyWithSign(remaining, currency) }}
           </div>
         </div>
       </div>
@@ -61,16 +66,14 @@
         class="q-mt-sm"
       />
 
-      <div class="text-caption text-grey-6 q-mt-xs">
-        {{ Math.round(progressPercentage) }}% of budget spent
-      </div>
+      <div class="text-caption q-mt-xs">{{ Math.round(progressPercentage) }}% of budget spent</div>
     </q-card-section>
   </q-card>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { formatCurrency, type CurrencyCode } from 'src/utils/currency'
+import { formatCurrency, formatCurrencyWithSign, type CurrencyCode } from 'src/utils/currency'
 import { getStatusText, getStatusColor, getStatusIcon, formatDateRange } from 'src/utils/plans'
 import { getBudgetProgressColor, getBudgetRemainingColorClass } from 'src/utils/budget'
 import type { PlanWithItems } from 'src/api'

--- a/src/components/plans/PlanTemplateSelection.vue
+++ b/src/components/plans/PlanTemplateSelection.vue
@@ -10,7 +10,7 @@
       spacing="q-mb-xs"
     />
 
-    <div class="text-body2 text-grey-6 q-mb-md">
+    <div class="text-body2 text-muted q-mb-md">
       Select a template to base your plan on. You can modify the items and amounts after selection.
     </div>
 

--- a/src/components/plans/RecentExpensesList.vue
+++ b/src/components/plans/RecentExpensesList.vue
@@ -122,13 +122,13 @@
               >
                 <div class="row items-center q-gutter-sm">
                   <div class="column items-end">
-                    <q-item-label class="text-weight-bold text-primary">
+                    <q-item-label class="text-weight-bold text-primary text-amount">
                       {{ formatCurrency(expense.amount, currency) }}
                     </q-item-label>
                     <q-item-label
                       v-if="expense.original_amount && expense.original_currency"
                       caption
-                      class="text-caption text-grey-6"
+                      class="text-caption text-amount"
                     >
                       {{
                         formatCurrency(
@@ -174,13 +174,13 @@
             >
               <div class="row items-center q-gutter-sm">
                 <div class="column items-end">
-                  <q-item-label class="text-weight-bold text-primary">
+                  <q-item-label class="text-weight-bold text-primary text-amount">
                     {{ formatCurrency(expense.amount, currency) }}
                   </q-item-label>
                   <q-item-label
                     v-if="expense.original_amount && expense.original_currency"
                     caption
-                    class="text-caption text-grey-6"
+                    class="text-caption text-amount"
                   >
                     {{
                       formatCurrency(
@@ -209,7 +209,7 @@
 
       <div
         v-else
-        class="text-center text-grey-6 q-py-lg"
+        class="text-center text-muted q-py-lg"
       >
         <q-icon
           name="eva-shopping-cart-outline"

--- a/src/components/settings/SettingsSectionCard.vue
+++ b/src/components/settings/SettingsSectionCard.vue
@@ -9,7 +9,7 @@
       </div>
       <div
         v-if="description"
-        class="text-caption text-grey-6 q-mt-xs"
+        class="text-caption q-mt-xs"
       >
         {{ description }}
       </div>

--- a/src/components/shared/AppBanner.vue
+++ b/src/components/shared/AppBanner.vue
@@ -71,23 +71,23 @@ let autoDismissTimer: ReturnType<typeof setTimeout> | null = null
 const variantConfig = computed(() => {
   const configs: Record<BannerVariant, { bg: string; text: string; icon: string }> = {
     success: {
-      bg: 'bg-green-1',
-      text: 'text-green-6',
+      bg: 'bg-success-soft',
+      text: 'text-success-strong',
       icon: 'eva-checkmark-circle-outline',
     },
     error: {
-      bg: 'bg-red-1',
-      text: 'text-red-6',
+      bg: 'bg-destructive-soft',
+      text: 'text-destructive-strong',
       icon: 'eva-alert-triangle-outline',
     },
     warning: {
-      bg: 'bg-orange-1',
-      text: 'text-orange-6',
+      bg: 'bg-warning-soft',
+      text: 'text-warning-strong',
       icon: 'eva-alert-triangle-outline',
     },
     info: {
-      bg: 'bg-cyan-1',
-      text: 'text-cyan-6',
+      bg: 'bg-info-soft',
+      text: 'text-info-strong',
       icon: 'eva-info-outline',
     },
   }

--- a/src/components/shared/BrandIllustration.vue
+++ b/src/components/shared/BrandIllustration.vue
@@ -1,0 +1,197 @@
+<template>
+  <svg
+    class="brand-illustration"
+    :width="props.width"
+    viewBox="0 0 160 120"
+    fill="none"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <!-- Lost sheep (brand motif) -->
+    <g v-if="name === 'sheep'">
+      <line
+        class="illu-muted"
+        x1="30"
+        y1="104"
+        x2="130"
+        y2="104"
+        stroke-dasharray="2 8"
+      />
+      <rect
+        class="illu-accent"
+        x="35"
+        y="45"
+        width="70"
+        height="42"
+        rx="21"
+      />
+      <path
+        class="illu-accent"
+        d="M47 45q4-9 13-8M65 42q5-8 14-6M83 40q6-7 13-3"
+      />
+      <circle
+        class="illu-accent"
+        cx="112"
+        cy="52"
+        r="12"
+      />
+      <path
+        class="illu-accent"
+        d="M120 43q8-4 10 2-4 4-9 2"
+      />
+      <circle
+        class="illu-dot"
+        cx="109"
+        cy="50"
+        r="1.6"
+      />
+      <circle
+        class="illu-dot"
+        cx="115.5"
+        cy="50"
+        r="1.6"
+      />
+      <path
+        class="illu-accent"
+        d="M35 60q-8 2-6 10"
+      />
+      <path
+        class="illu-accent"
+        d="M55 87v14M75 87v14M95 87v14"
+      />
+    </g>
+
+    <!-- Calendar with sprout (plans) -->
+    <g v-else-if="name === 'plan'">
+      <rect
+        class="illu-accent"
+        x="45"
+        y="35"
+        width="70"
+        height="60"
+        rx="8"
+      />
+      <path
+        class="illu-accent"
+        d="M60 27v14M100 27v14M45 52h70"
+      />
+      <path
+        class="illu-accent"
+        d="M80 85V70"
+      />
+      <path
+        class="illu-accent"
+        d="M80 72q-10-2-12-12 10 0 12 12zM80 76q10-2 12-12-10 0-12 12z"
+      />
+      <circle
+        class="illu-dot-muted"
+        cx="58"
+        cy="62"
+        r="1.6"
+      />
+      <circle
+        class="illu-dot-muted"
+        cx="70"
+        cy="62"
+        r="1.6"
+      />
+      <circle
+        class="illu-dot-muted"
+        cx="90"
+        cy="62"
+        r="1.6"
+      />
+      <circle
+        class="illu-dot-muted"
+        cx="102"
+        cy="62"
+        r="1.6"
+      />
+    </g>
+
+    <!-- Receipt with add-coin (expenses) -->
+    <g v-else-if="name === 'receipt'">
+      <path
+        class="illu-accent"
+        d="M50 25h50v63l-6.25 6-6.25-6-6.25 6-6.25-6-6.25 6-6.25-6-6.25 6-6.25-6z"
+      />
+      <path
+        class="illu-muted"
+        d="M58 40h26M58 50h34M58 60h20"
+      />
+      <circle
+        class="illu-accent"
+        cx="112"
+        cy="78"
+        r="14"
+      />
+      <path
+        class="illu-accent"
+        d="M112 71v14M105 78h14"
+      />
+    </g>
+
+    <!-- Stacked documents (templates) -->
+    <g v-else-if="name === 'template'">
+      <rect
+        class="illu-muted"
+        x="50"
+        y="28"
+        width="48"
+        height="58"
+        rx="6"
+      />
+      <rect
+        class="illu-accent"
+        x="62"
+        y="38"
+        width="48"
+        height="58"
+        rx="6"
+      />
+      <path
+        class="illu-muted"
+        d="M70 52h28M70 62h32M70 72h20"
+      />
+    </g>
+  </svg>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    name: 'sheep' | 'plan' | 'receipt' | 'template'
+    width?: number
+  }>(),
+  {
+    width: 160,
+  },
+)
+</script>
+
+<style lang="scss" scoped>
+.brand-illustration {
+  display: block;
+  margin: 0 auto;
+
+  .illu-accent {
+    stroke: hsl(var(--primary) / 0.75);
+  }
+
+  .illu-muted {
+    stroke: hsl(var(--muted-foreground) / 0.45);
+  }
+
+  .illu-dot {
+    fill: hsl(var(--primary) / 0.75);
+    stroke: none;
+  }
+
+  .illu-dot-muted {
+    fill: hsl(var(--muted-foreground) / 0.45);
+    stroke: none;
+  }
+}
+</style>

--- a/src/components/shared/CompactDisplayItemRow.vue
+++ b/src/components/shared/CompactDisplayItemRow.vue
@@ -32,7 +32,7 @@
       class="compact-display-item__amount-section q-pl-sm"
     >
       <q-item-label
-        class="compact-display-item__amount text-right text-no-wrap"
+        class="compact-display-item__amount text-right text-no-wrap text-amount"
         :class="amountClass"
       >
         {{ formattedAmount }}
@@ -71,18 +71,18 @@ const formattedAmount = computed(() => formatCurrency(props.amount, props.curren
 
 const nameClass = computed(() => {
   if (props.muted) {
-    return props.strike ? 'text-grey-5' : 'text-grey-6'
+    return props.strike ? 'text-faint' : 'text-muted'
   }
 
-  return props.strike ? 'text-grey-6' : 'text-weight-medium'
+  return props.strike ? 'text-muted' : 'text-weight-medium'
 })
 
 const amountClass = computed(() => {
   if (props.muted) {
-    return props.strike ? 'text-grey-5' : 'text-grey-7'
+    return props.strike ? 'text-faint' : 'text-muted'
   }
 
-  return props.strike ? 'text-grey-5' : ''
+  return props.strike ? 'text-faint' : ''
 })
 </script>
 

--- a/src/components/shared/DeleteDialog.vue
+++ b/src/components/shared/DeleteDialog.vue
@@ -12,7 +12,7 @@
   >
     <q-banner
       rounded
-      class="bg-red-1 text-red-8 q-mb-md"
+      class="bg-destructive-soft text-destructive-strong q-mb-md"
     >
       <template #avatar>
         <q-icon

--- a/src/components/shared/EmptyState.vue
+++ b/src/components/shared/EmptyState.vue
@@ -5,17 +5,23 @@
     class="text-center q-py-lg"
   >
     <q-card-section>
+      <BrandIllustration
+        v-if="illustration && !hasSearchQuery"
+        :name="illustration"
+        class="q-mb-sm"
+      />
       <q-icon
+        v-else
         :name="currentIcon"
         size="4rem"
-        class="text-grey-4 q-mb-md"
+        class="text-faint q-mb-md"
       />
 
-      <h3 class="text-h5 q-mb-sm q-mt-none text-grey-7">
+      <h3 class="text-h5 q-mb-sm q-mt-none">
         {{ currentTitle }}
       </h3>
 
-      <p class="text-body2 text-grey-5 q-mb-lg">
+      <p class="text-body2 text-muted q-mb-lg">
         {{ currentDescription }}
       </p>
 
@@ -46,6 +52,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import BrandIllustration from 'src/components/shared/BrandIllustration.vue'
 
 const emit = defineEmits<{
   (e: 'clearSearch'): void
@@ -55,6 +62,7 @@ const emit = defineEmits<{
 const props = withDefaults(
   defineProps<{
     hasSearchQuery: boolean
+    illustration?: 'sheep' | 'plan' | 'receipt' | 'template'
     searchIcon?: string
     emptyIcon?: string
     searchTitle?: string

--- a/src/components/shared/FormErrorSummary.vue
+++ b/src/components/shared/FormErrorSummary.vue
@@ -35,7 +35,7 @@ const bannerClasses = computed(() => [
   'q-pa-sm',
   'q-px-md',
   'q-mb-md',
-  'bg-red-1',
-  'text-red-6',
+  'bg-destructive-soft',
+  'text-destructive-strong',
 ])
 </script>

--- a/src/components/shared/ItemCategory.vue
+++ b/src/components/shared/ItemCategory.vue
@@ -32,8 +32,8 @@
 
         <q-item-section side>
           <div class="text-right">
-            <div class="text-weight-bold text-primary">{{ formattedSubtotal }}</div>
-            <div class="text-caption text-grey-6">subtotal</div>
+            <div class="text-weight-bold text-primary text-amount">{{ formattedSubtotal }}</div>
+            <div class="text-caption">subtotal</div>
           </div>
         </q-item-section>
       </template>

--- a/src/components/shared/ItemsSummarySection.vue
+++ b/src/components/shared/ItemsSummarySection.vue
@@ -18,14 +18,14 @@
       </div>
       <div
         :class="[
-          'text-primary text-weight-bold',
+          'text-primary text-weight-bold text-amount',
           $q.screen.lt.md ? amountSizeMobile : amountSizeDesktop,
         ]"
       >
         {{ formattedAmount }}
       </div>
     </div>
-    <div class="text-body2 text-grey-6">
+    <div class="text-body2 text-muted">
       {{ description }}
     </div>
   </div>

--- a/src/components/shared/ShareDialog.vue
+++ b/src/components/shared/ShareDialog.vue
@@ -38,7 +38,7 @@
 
     <!-- People with access -->
     <div class="q-mt-md">
-      <div class="text-caption text-grey-6 q-mb-xs">
+      <div class="text-caption q-mb-xs">
         People with access{{
           !isLoadingShares && visibleSharedUsers.length > 0 ? ` (${visibleSharedUsers.length})` : ''
         }}
@@ -89,7 +89,7 @@
       <!-- Empty state -->
       <div
         v-else
-        class="text-caption text-grey-6 q-py-sm"
+        class="text-caption q-py-sm"
       >
         Not shared with anyone yet
       </div>

--- a/src/components/shared/SharedUsersSelect.vue
+++ b/src/components/shared/SharedUsersSelect.vue
@@ -60,19 +60,19 @@
         <q-item-section class="text-center">
           <div v-if="loading">
             <q-spinner-dots />
-            <div class="text-grey-6">Searching...</div>
+            <div class="text-muted">Searching...</div>
           </div>
           <div v-else-if="searchQuery?.trim()">
             <q-icon
               name="eva-search-outline"
               size="2rem"
-              class="text-grey-5 q-mb-sm"
+              class="text-faint q-mb-sm"
             />
-            <div class="text-grey-7">No users found for "{{ searchQuery }}"</div>
-            <div class="text-caption text-grey-5 q-mt-xs">Try a different email address</div>
+            <div class="text-muted">No users found for "{{ searchQuery }}"</div>
+            <div class="text-caption text-faint q-mt-xs">Try a different email address</div>
           </div>
           <div v-else>
-            <div class="text-grey-6">Type an email address to search</div>
+            <div class="text-muted">Type an email address to search</div>
           </div>
         </q-item-section>
       </q-item>

--- a/src/components/templates/TemplateCard.vue
+++ b/src/components/templates/TemplateCard.vue
@@ -42,7 +42,7 @@
               round
               size="sm"
               icon="eva-more-vertical-outline"
-              class="text-grey-7"
+              class="text-muted"
               :aria-label="menuButtonLabel"
               aria-haspopup="menu"
               @click.stop
@@ -60,7 +60,7 @@
         <div class="q-mt-lg">
           <div class="row items-center justify-between">
             <div class="col">
-              <div class="text-subtitle1 text-weight-bold text-primary">
+              <div class="text-subtitle1 text-weight-bold text-primary text-amount">
                 {{ formatAmount(template.total) }}
               </div>
             </div>
@@ -82,7 +82,7 @@
           </div>
           <div class="row items-center">
             <div class="col">
-              <div class="text-caption text-grey-6">Total amount</div>
+              <div class="text-caption">Total amount</div>
             </div>
           </div>
         </div>

--- a/src/components/templates/TemplateEditView.vue
+++ b/src/components/templates/TemplateEditView.vue
@@ -53,7 +53,7 @@
         :all-expanded="allExpanded"
         :has-duplicates="hasDuplicates"
         duplicate-banner-position="top"
-        duplicate-banner-class="bg-orange-1 text-orange-8"
+        duplicate-banner-class="bg-warning-soft text-warning-strong"
         show-item-count
         :bordered="false"
         :padding="false"
@@ -110,12 +110,15 @@
               <h3 class="text-h6 q-my-none">Total Amount</h3>
             </div>
             <div
-              :class="['text-primary text-weight-bold', $q.screen.lt.md ? 'text-h6' : 'text-h5']"
+              :class="[
+                'text-primary text-weight-bold text-amount',
+                $q.screen.lt.md ? 'text-h6' : 'text-h5',
+              ]"
             >
               {{ formattedTotal }}
             </div>
           </div>
-          <div class="text-caption text-grey-6">
+          <div class="text-caption">
             Total across {{ categoryGroups.length }}
             {{ categoryGroups.length === 1 ? 'category' : 'categories' }}
           </div>

--- a/src/components/templates/TemplateReadOnlyView.vue
+++ b/src/components/templates/TemplateReadOnlyView.vue
@@ -16,10 +16,10 @@
           <q-icon
             name="eva-grid-outline"
             size="4rem"
-            class="text-grey-4 q-mb-md"
+            class="text-faint q-mb-md"
           />
-          <div class="text-h6 q-mb-sm text-grey-6">No categories</div>
-          <div class="text-body2 text-grey-5 q-mb-lg">This template doesn't have any items yet</div>
+          <div class="text-h6 q-mb-sm text-muted">No categories</div>
+          <div class="text-body2 text-faint q-mb-lg">This template doesn't have any items yet</div>
         </div>
       </q-card-section>
     </q-card>
@@ -69,12 +69,15 @@
               <h3 class="text-h6 q-my-none">Total Amount</h3>
             </div>
             <div
-              :class="['text-primary text-weight-bold', $q.screen.lt.md ? 'text-h6' : 'text-h5']"
+              :class="[
+                'text-primary text-weight-bold text-amount',
+                $q.screen.lt.md ? 'text-h6' : 'text-h5',
+              ]"
             >
               {{ formattedTotal }}
             </div>
           </div>
-          <div class="text-body2 text-grey-6">
+          <div class="text-body2 text-muted">
             Total across {{ categoryGroups.length }}
             {{ categoryGroups.length === 1 ? 'category' : 'categories' }}
           </div>

--- a/src/composables/useCountUp.test.ts
+++ b/src/composables/useCountUp.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { ref, nextTick, effectScope } from 'vue'
+import { useCountUp } from './useCountUp'
+
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({ matches })),
+  )
+}
+
+describe('useCountUp', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('initializes with the target value', () => {
+    stubMatchMedia(false)
+
+    const scope = effectScope()
+    scope.run(() => {
+      const target = ref(120)
+      const { displayValue } = useCountUp(target)
+      expect(displayValue.value).toBe(120)
+    })
+    scope.stop()
+  })
+
+  it('renders the target instantly when the user prefers reduced motion', async () => {
+    stubMatchMedia(true)
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const target = ref(0)
+      const { displayValue } = useCountUp(target)
+
+      target.value = 250
+      await nextTick()
+
+      expect(displayValue.value).toBe(250)
+    })
+    scope.stop()
+  })
+
+  it('renders the target instantly when animations are disabled', async () => {
+    stubMatchMedia(false)
+
+    const scope = effectScope()
+    await scope.run(async () => {
+      const target = ref(0)
+      const { displayValue } = useCountUp(target, { enabled: false })
+
+      target.value = 99
+      await nextTick()
+
+      expect(displayValue.value).toBe(99)
+    })
+    scope.stop()
+  })
+})

--- a/src/composables/useCountUp.ts
+++ b/src/composables/useCountUp.ts
@@ -1,0 +1,65 @@
+import { ref, watch, onScopeDispose, toValue, type MaybeRefOrGetter } from 'vue'
+
+/**
+ * Animates a number toward its target value (hero metric count-up).
+ * Renders the final value instantly when the user prefers reduced motion
+ * or when `enabled` resolves to false (e.g. privacy mode).
+ */
+export function useCountUp(
+  target: MaybeRefOrGetter<number>,
+  options: { duration?: number; enabled?: MaybeRefOrGetter<boolean> } = {},
+) {
+  const duration = options.duration ?? 400
+  const displayValue = ref(toValue(target))
+  let rafId = 0
+
+  function prefersReducedMotion(): boolean {
+    return typeof window !== 'undefined'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : true
+  }
+
+  function stop() {
+    if (rafId) {
+      cancelAnimationFrame(rafId)
+      rafId = 0
+    }
+  }
+
+  watch(
+    () => toValue(target),
+    (to) => {
+      stop()
+
+      const animationsEnabled = toValue(options.enabled ?? true)
+      if (!animationsEnabled || prefersReducedMotion() || typeof window === 'undefined') {
+        displayValue.value = to
+        return
+      }
+
+      const from = displayValue.value
+      if (from === to) return
+
+      const start = performance.now()
+
+      function step(now: number) {
+        const progress = Math.min((now - start) / duration, 1)
+        const eased = 1 - Math.pow(1 - progress, 3)
+        displayValue.value = from + (to - from) * eased
+
+        if (progress < 1) {
+          rafId = requestAnimationFrame(step)
+        } else {
+          displayValue.value = to
+          rafId = 0
+        }
+      }
+
+      rafId = requestAnimationFrame(step)
+    },
+  )
+
+  onScopeDispose(stop)
+
+  return { displayValue }
+}

--- a/src/composables/useInstallPromptGate.test.ts
+++ b/src/composables/useInstallPromptGate.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import { useInstallPromptGate } from './useInstallPromptGate'
+
+const STORAGE_KEY = 'shephard-has-saved-expense'
+
+describe('useInstallPromptGate', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('defaults to no saved expense', () => {
+    const { hasSavedExpense } = useInstallPromptGate()
+    expect(hasSavedExpense.value).toBe(false)
+  })
+
+  it('marks the expense as saved and persists the flag', async () => {
+    const { hasSavedExpense, markExpenseSaved } = useInstallPromptGate()
+
+    markExpenseSaved()
+    await nextTick()
+
+    expect(hasSavedExpense.value).toBe(true)
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true')
+  })
+
+  it('restores the persisted flag for new consumers', () => {
+    localStorage.setItem(STORAGE_KEY, 'true')
+
+    const { hasSavedExpense } = useInstallPromptGate()
+    expect(hasSavedExpense.value).toBe(true)
+  })
+})

--- a/src/composables/useInstallPromptGate.ts
+++ b/src/composables/useInstallPromptGate.ts
@@ -1,0 +1,20 @@
+import { useStorage } from '@vueuse/core'
+
+const HAS_SAVED_EXPENSE_KEY = 'shephard-has-saved-expense'
+
+/**
+ * Gates the PWA install promotion behind the first successfully saved expense,
+ * so the prompt appears right after the user experiences value — not on load.
+ */
+export function useInstallPromptGate() {
+  const hasSavedExpense = useStorage(HAS_SAVED_EXPENSE_KEY, false)
+
+  function markExpenseSaved() {
+    hasSavedExpense.value = true
+  }
+
+  return {
+    hasSavedExpense,
+    markExpenseSaved,
+  }
+}

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -5,6 +5,8 @@ html {
   color: $text-color;
   padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px) 0
     env(safe-area-inset-left, 0px);
+  // App-level pull-to-refresh (QPullToRefresh) replaces the browser's native reload gesture
+  overscroll-behavior-y: none;
 }
 
 html:has(.body--dark) {
@@ -871,6 +873,62 @@ h6,
 
 .text-muted {
   color: hsl(var(--muted-foreground));
+}
+
+.text-faint {
+  color: hsl(var(--muted-foreground) / 0.75);
+}
+
+.bg-muted {
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+// Money typography: tabular figures so amounts align and don't wiggle when animated
+.text-amount {
+  font-variant-numeric: tabular-nums lining-nums;
+}
+
+// Display scale for hero metrics (glanceable money numbers)
+.text-display {
+  font-size: clamp(2.25rem, 8vw, 2.75rem);
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums lining-nums;
+}
+
+// Soft semantic surfaces — theme-aware replacements for bg-red-1/text-red-8 etc.
+.bg-destructive-soft {
+  background: hsl(var(--destructive-soft-bg));
+}
+
+.text-destructive-strong {
+  color: hsl(var(--destructive-soft-fg));
+}
+
+.bg-warning-soft {
+  background: hsl(var(--warning-soft-bg));
+}
+
+.text-warning-strong {
+  color: hsl(var(--warning-soft-fg));
+}
+
+.bg-success-soft {
+  background: hsl(var(--success-soft-bg));
+}
+
+.text-success-strong {
+  color: hsl(var(--success-soft-fg));
+}
+
+.bg-info-soft {
+  background: hsl(var(--info-soft-bg));
+}
+
+.text-info-strong {
+  color: hsl(var(--info-soft-fg));
 }
 
 .text-caption-secondary {

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -35,11 +35,11 @@ $cyan-6: #00454a !default;
 $cyan-7: #002427 !default;
 
 $primary: #00919a;
-$secondary: #a47b7b;
+$secondary: #576b75;
 $accent: #00919a;
 
-$dark: #0a0a0a;
-$dark-page: #0a0a0a;
+$dark: #121212;
+$dark-page: #121212;
 $bg-color: hsl(0, 0%, 97%);
 $text-color: #32302d;
 

--- a/src/css/theme.scss
+++ b/src/css/theme.scss
@@ -27,7 +27,7 @@
   --primary: 184 100% 30%; // #00919a
   --primary-foreground: 0 0% 100%;
 
-  --secondary: 0 18% 56%; // #a47b7b
+  --secondary: 200 15% 40%; // slate teal #576b75
   --secondary-foreground: 0 0% 100%;
 
   --muted: 210 40% 96%;
@@ -44,6 +44,34 @@
 
   --warning: 16 99% 63%; // #fe7743
   --warning-foreground: 0 0% 100%;
+
+  --info: 187 16% 43%; // #5d7c80
+  --info-foreground: 0 0% 100%;
+
+  // Soft semantic surfaces (banners, badges, hint chips) — bg + readable fg pairs
+  --destructive-soft-bg: 352 92% 59% / 0.1;
+  --destructive-soft-fg: 352 74% 38%;
+  --warning-soft-bg: 16 99% 63% / 0.12;
+  --warning-soft-fg: 18 85% 34%;
+  --success-soft-bg: 147 79% 31% / 0.1;
+  --success-soft-fg: 147 79% 24%;
+  --info-soft-bg: 187 16% 43% / 0.12;
+  --info-soft-fg: 187 22% 30%;
+
+  // Chart / category accent hues (distinct from over/under-budget semantics)
+  --chart-1: 210 78% 46%; // blue
+  --chart-2: 262 55% 52%; // violet
+  --chart-3: 32 90% 42%; // amber
+  --chart-4: 184 100% 30%; // teal (brand)
+  --chart-5: 336 62% 48%; // magenta
+
+  // Hero money surface (dashboard brand moment)
+  --hero-gradient-from: 184 100% 26%;
+  --hero-gradient-to: 197 88% 18%;
+  --hero-glow: 174 100% 45% / 0.35;
+  --hero-foreground: 0 0% 100%;
+  --hero-muted: 184 45% 86%;
+  --hero-track: 0 0% 100% / 0.22;
 
   --border: 214 32% 91%;
   --input: 214 32% 91%;
@@ -128,22 +156,23 @@
 
 // Dark mode variables
 .body--dark {
-  --background: 0 0% 4%;
+  // Layered dark surfaces (#121212 family) instead of near-black
+  --background: 0 0% 7%;
   --foreground: 0 0% 98%;
 
-  --card: 0 0% 9%;
+  --card: 0 0% 11%;
   --card-foreground: 0 0% 98%;
 
-  --popover: 0 0% 9%;
+  --popover: 0 0% 11%;
   --popover-foreground: 0 0% 98%;
 
   --primary: 184 100% 35%; // Slightly brighter
   --primary-foreground: 0 0% 100%;
 
-  --secondary: 0 18% 40%;
-  --secondary-foreground: 0 0% 98%;
+  --secondary: 200 15% 65%;
+  --secondary-foreground: 200 25% 12%;
 
-  --muted: 0 0% 14%;
+  --muted: 0 0% 16%;
   --muted-foreground: 0 0% 70%;
 
   --accent: 184 100% 35%;
@@ -158,6 +187,34 @@
   --warning: 16 90% 55%;
   --warning-foreground: 0 0% 100%;
 
+  --info: 187 16% 55%;
+  --info-foreground: 0 0% 10%;
+
+  // Soft semantic surfaces
+  --destructive-soft-bg: 352 80% 45% / 0.18;
+  --destructive-soft-fg: 352 95% 75%;
+  --warning-soft-bg: 16 90% 55% / 0.16;
+  --warning-soft-fg: 20 95% 72%;
+  --success-soft-bg: 147 70% 40% / 0.16;
+  --success-soft-fg: 147 55% 65%;
+  --info-soft-bg: 187 16% 55% / 0.16;
+  --info-soft-fg: 187 25% 72%;
+
+  // Chart / category accent hues (brightened for dark surfaces)
+  --chart-1: 210 85% 62%;
+  --chart-2: 262 70% 70%;
+  --chart-3: 36 92% 58%;
+  --chart-4: 184 90% 44%;
+  --chart-5: 336 75% 65%;
+
+  // Hero money surface
+  --hero-gradient-from: 184 85% 20%;
+  --hero-gradient-to: 200 80% 13%;
+  --hero-glow: 174 100% 45% / 0.28;
+  --hero-foreground: 0 0% 100%;
+  --hero-muted: 184 35% 80%;
+  --hero-track: 0 0% 100% / 0.2;
+
   --border: 0 0% 100% / 0.1;
   --input: 0 0% 100% / 0.15;
   --ring: 184 100% 35%;
@@ -169,11 +226,11 @@
   --shadow-lg: 0 8px 16px -8px rgb(0 0 0 / 0.36);
 
   // Tabs
-  --tab-surface: 0 0% 11%;
+  --tab-surface: 0 0% 14%;
   --tab-surface-border: 0 0% 100% / 0.08;
   --tab-surface-highlight: 0 0% 100% / 0.08;
   --tab-surface-hover: 0 0% 100% / 0.08;
-  --tab-active-bg: 0 0% 16%;
+  --tab-active-bg: 0 0% 20%;
   --tab-active-foreground: 184 100% 42%;
   --tab-inactive-foreground: 0 0% 72%;
   --tab-active-shadow: 0 14px 22px -20px rgb(0 0 0 / 0.72), 0 4px 10px -8px rgb(0 0 0 / 0.44);

--- a/src/layouts/BaseItemFormPage.vue
+++ b/src/layouts/BaseItemFormPage.vue
@@ -50,7 +50,7 @@ const computedBanners = computed(() => {
   if (!props.isEditMode) {
     bannersList.push({
       type: 'readonly',
-      class: 'bg-orange-1 text-orange-8',
+      class: 'bg-warning-soft text-warning-strong',
       icon: 'eva-eye-outline',
       message: 'Read-only access. Contact the owner to edit.',
     })

--- a/src/layouts/DetailPageLayout.test.ts
+++ b/src/layouts/DetailPageLayout.test.ts
@@ -55,8 +55,11 @@ it('should render toolbar with back button', () => {
   const backButton = wrapper.find('button')
 
   expect(toolbar.exists()).toBe(true)
-  expect(toolbar.classes()).toContain('q-mb-lg')
-  expect(toolbar.classes()).toContain('q-px-none')
+  expect(toolbar.classes()).toContain('q-px-md')
+  expect(toolbar.classes()).toContain('q-py-sm')
+  expect(toolbar.classes()).toContain('sticky-toolbar')
+  expect(toolbar.classes()).toContain('detail-toolbar')
+  expect(toolbar.classes()).toContain('liquid-glass-surface')
   expect(backButton.exists()).toBe(true)
   expect(backButton.classes()).toContain('q-btn--flat')
   expect(backButton.classes()).toContain('q-btn--round')

--- a/src/layouts/DetailPageLayout.vue
+++ b/src/layouts/DetailPageLayout.vue
@@ -78,7 +78,9 @@
     >
       <div class="row justify-center">
         <div class="col-12 col-lg-10 col-xl-8">
-          <q-toolbar class="q-mb-lg q-px-none q-pa-md sticky-toolbar detail-toolbar toolbar-border">
+          <q-toolbar
+            class="q-mb-lg q-px-md q-py-sm sticky-toolbar detail-toolbar liquid-glass-surface"
+          >
             <q-btn
               flat
               round
@@ -244,12 +246,7 @@ const hasActions = computed(() => {
 }
 
 .detail-toolbar {
-  background: hsl(var(--card));
   color: hsl(var(--foreground));
-}
-
-.toolbar-border {
-  border-bottom: 1px solid hsl(var(--border));
 }
 
 .detail-title-basis {

--- a/src/layouts/ListPageLayout.test.ts
+++ b/src/layouts/ListPageLayout.test.ts
@@ -69,7 +69,7 @@ it('should render description with correct styling', () => {
   expect(descriptionElement.exists()).toBe(true)
   expect(descriptionElement.text()).toBe('Custom description text')
   expect(descriptionElement.classes()).toContain('text-body2')
-  expect(descriptionElement.classes()).toContain('text-grey-6')
+  expect(descriptionElement.classes()).toContain('text-muted')
   expect(descriptionElement.classes()).toContain('q-mb-none')
 })
 

--- a/src/layouts/ListPageLayout.vue
+++ b/src/layouts/ListPageLayout.vue
@@ -17,7 +17,7 @@
           >
             {{ title }}
           </h1>
-          <p class="text-body2 text-grey-6 q-mb-none gt-xs">
+          <p class="text-body2 text-muted q-mb-none gt-xs">
             {{ description }}
           </p>
         </div>

--- a/src/layouts/MainLayout.test.ts
+++ b/src/layouts/MainLayout.test.ts
@@ -1,10 +1,10 @@
-import { mount, flushPromises } from '@vue/test-utils'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest'
 import { createTestingPinia } from '@pinia/testing'
 import { vi, it, expect, beforeEach } from 'vitest'
 import type { ComponentProps } from 'vue-component-type-helpers'
 import { ref } from 'vue'
-import { Screen } from 'quasar'
+import { Screen, Notify } from 'quasar'
 import { defaultNotificationPushPreferences } from 'src/types/notifications'
 
 import MainLayout from './MainLayout.vue'
@@ -19,11 +19,22 @@ vi.mock('vue-router', () => ({
   useRoute: () => ({ fullPath: '/templates', params: {}, path: '/templates' }),
 }))
 
+const mockIsInstallable = ref(false)
+
 vi.mock('src/composables/usePwaInstall', () => ({
   usePwaInstall: () => ({
-    isInstallable: ref(false),
+    isInstallable: mockIsInstallable,
     promptInstall: vi.fn(),
     dismissInstall: vi.fn(),
+  }),
+}))
+
+const mockHasSavedExpense = ref(false)
+
+vi.mock('src/composables/useInstallPromptGate', () => ({
+  useInstallPromptGate: () => ({
+    hasSavedExpense: mockHasSavedExpense,
+    markExpenseSaved: vi.fn(),
   }),
 }))
 
@@ -123,6 +134,8 @@ beforeEach(() => {
   Screen.setDebounce(0)
   setScreenWidth(1280)
   vi.clearAllMocks()
+  mockIsInstallable.value = false
+  mockHasSavedExpense.value = false
 })
 
 it('should mount component properly', () => {
@@ -220,4 +233,55 @@ it('should open notifications in the shared mobile dialog shell', async () => {
   expect(notificationInbox.attributes('data-show-header')).toBe('false')
   expect(headerActions.exists()).toBe(true)
   expect(notificationsButton.attributes('aria-expanded')).toBe('true')
+})
+
+it('should include Activity in navigation items', () => {
+  const wrapper = renderMainLayout()
+
+  const navigationDrawer = wrapper.findComponent('[data-testid="navigation-drawer"]') as VueWrapper
+  const items = (navigationDrawer.props() as Record<'items', unknown>).items as Array<{
+    icon: string
+    label: string
+    to: string
+  }>
+
+  expect(items).toContainEqual({
+    icon: 'eva-activity-outline',
+    label: 'Activity',
+    to: '/expenses',
+  })
+  expect(items.map((item) => item.to)).toEqual(['/', '/plans', '/expenses', '/templates'])
+})
+
+it('should not prompt install while the user has not saved an expense', async () => {
+  const notifySpy = vi.spyOn(Notify, 'create').mockImplementation(() => () => {})
+
+  renderMainLayout()
+
+  mockIsInstallable.value = true
+  await flushPromises()
+
+  expect(notifySpy).not.toHaveBeenCalled()
+  notifySpy.mockRestore()
+})
+
+it('should prompt install only when installable and an expense has been saved', async () => {
+  const notifySpy = vi.spyOn(Notify, 'create').mockImplementation(() => () => {})
+
+  renderMainLayout()
+
+  mockHasSavedExpense.value = true
+  await flushPromises()
+  expect(notifySpy).not.toHaveBeenCalled()
+
+  mockIsInstallable.value = true
+  await flushPromises()
+
+  // Wrappers from earlier tests stay mounted and share the mocked refs,
+  // so assert the prompt fired rather than an exact call count.
+  expect(notifySpy).toHaveBeenCalled()
+  expect(notifySpy).toHaveBeenCalledWith(
+    expect.objectContaining({ message: 'Install Shephard for a better experience!' }),
+  )
+  notifySpy.mockRestore()
 })

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -151,6 +151,7 @@ import NotificationInboxHeaderActions from 'src/components/notifications/Notific
 import AppDialogShell from 'src/components/shared/AppDialogShell.vue'
 import { useUserStore } from 'src/stores/user'
 import { usePwaInstall } from 'src/composables/usePwaInstall'
+import { useInstallPromptGate } from 'src/composables/useInstallPromptGate'
 import { useNotifications } from 'src/composables/useNotifications'
 
 useMeta({
@@ -161,6 +162,7 @@ const userStore = useUserStore()
 const route = useRoute()
 const $q = useQuasar()
 const { isInstallable, promptInstall, dismissInstall } = usePwaInstall()
+const { hasSavedExpense } = useInstallPromptGate()
 const ExpenseRegistrationDialog = defineAsyncComponent(
   () => import('src/components/expenses/ExpenseRegistrationDialog.vue'),
 )
@@ -217,8 +219,11 @@ async function handleOpenNotification(notification: (typeof notifications.value)
   showNotificationsDialog.value = false
 }
 
-watch(isInstallable, (installable) => {
-  if (installable) {
+// Promote install only after the user has experienced value (first saved expense)
+const shouldPromptInstall = computed(() => isInstallable.value && hasSavedExpense.value)
+
+watch(shouldPromptInstall, (promptable) => {
+  if (promptable) {
     showPwaInstallNotification()
   }
 })
@@ -260,6 +265,11 @@ const navigationItems = [
     to: '/plans',
   },
   {
+    icon: 'eva-activity-outline',
+    label: 'Activity',
+    to: '/expenses',
+  },
+  {
     icon: 'eva-file-text-outline',
     label: 'Templates',
     to: '/templates',
@@ -282,9 +292,21 @@ const showMobileBottomNav = computed(() => {
 }
 
 :deep(.notifications-menu-panel) {
-  border: 1px solid hsl(var(--border));
+  border: 1px solid hsl(var(--glass-border-outer));
   border-radius: var(--radius-xl);
-  background: hsl(var(--card));
-  box-shadow: var(--shadow-lg);
+  background: hsl(var(--glass-bg-fallback));
+  box-shadow: var(--glass-shadow);
+
+  @supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+    background: hsl(var(--glass-bg));
+    -webkit-backdrop-filter: saturate(var(--glass-saturation)) blur(var(--glass-blur));
+    backdrop-filter: saturate(var(--glass-saturation)) blur(var(--glass-blur));
+  }
+
+  @media (prefers-reduced-transparency: reduce) {
+    background: hsl(var(--card));
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
 }
 </style>

--- a/src/pages/AuthCallbackPage.vue
+++ b/src/pages/AuthCallbackPage.vue
@@ -3,7 +3,7 @@
     <q-inner-loading
       :showing="isLoading"
       label="Verifying your login..."
-      label-class="text-body2 text-grey-7"
+      label-class="text-body2 text-muted"
     />
 
     <div
@@ -37,7 +37,7 @@
         color="positive"
       />
       <p class="text-subtitle1 q-mt-md text-positive">Successfully authenticated!</p>
-      <p class="text-body2 text-grey-7">Redirecting you...</p>
+      <p class="text-body2 text-muted">Redirecting you...</p>
     </div>
   </AuthLoginCard>
 </template>

--- a/src/pages/AuthPage.vue
+++ b/src/pages/AuthPage.vue
@@ -6,7 +6,7 @@
     <!-- Divider with OR -->
     <div class="row items-center q-my-lg">
       <q-separator class="col" />
-      <span class="q-px-md text-caption text-uppercase text-grey-6">or continue with</span>
+      <span class="q-px-md text-caption text-uppercase">or continue with</span>
       <q-separator class="col" />
     </div>
 

--- a/src/pages/ErrorNotFound.test.ts
+++ b/src/pages/ErrorNotFound.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { it, expect } from 'vitest'
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest'
 import ErrorNotFound from './ErrorNotFound.vue'
+import BrandIllustration from 'src/components/shared/BrandIllustration.vue'
 
 installQuasarPlugin()
 
@@ -28,12 +29,13 @@ it('should display 404 error code', () => {
 
 it('should display page not found title', () => {
   const wrapper = createWrapper()
-  expect(wrapper.text()).toContain('Page Not Found')
+  expect(wrapper.text()).toContain('This page wandered off')
 })
 
 it('should display helpful message', () => {
   const wrapper = createWrapper()
   expect(wrapper.text()).toContain("The page you're looking for doesn't exist or has been moved")
+  expect(wrapper.text()).toContain("Let's get you back to the flock:")
 })
 
 it('should render go to home button with correct attributes', () => {
@@ -66,11 +68,12 @@ it('should have fullscreen layout with proper classes', () => {
   expect(wrapper.find('.fullscreen.column.flex-center.q-pa-xl').exists()).toBe(true)
 })
 
-it('should display error icon', () => {
+it('should display brand illustration', () => {
   const wrapper = createWrapper()
-  const icon = wrapper.findComponent({ name: 'QIcon' })
-  expect(icon.exists()).toBe(true)
-  expect(icon.attributes('name')).toBe('eva-alert-triangle-outline')
+  const illustration = wrapper.findComponent(BrandIllustration)
+  expect(illustration.exists()).toBe(true)
+  expect(illustration.props('name')).toBe('sheep')
+  expect(wrapper.find('svg.brand-illustration').exists()).toBe(true)
 })
 
 it('should render all three navigation buttons', () => {

--- a/src/pages/ErrorNotFound.vue
+++ b/src/pages/ErrorNotFound.vue
@@ -1,20 +1,19 @@
 <template>
   <div class="fullscreen column flex-center q-pa-xl">
     <div class="error-not-found__content column items-center text-center">
-      <q-icon
-        name="eva-alert-triangle-outline"
-        size="80px"
-        color="primary"
+      <BrandIllustration
+        name="sheep"
+        :width="220"
         class="q-mb-lg"
       />
 
       <div class="text-h1 text-weight-bold text-primary q-mb-md">404</div>
 
-      <div class="text-h5 q-mb-lg text-primary">Page Not Found</div>
+      <div class="text-h5 q-mb-lg text-primary">This page wandered off</div>
 
       <div class="text-body1 q-mb-xl">
         The page you're looking for doesn't exist or has been moved. <br />
-        Let's get you back on track with these helpful options:
+        Let's get you back to the flock:
       </div>
 
       <div class="row q-gutter-md">
@@ -57,6 +56,10 @@
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import BrandIllustration from 'src/components/shared/BrandIllustration.vue'
+</script>
 
 <style lang="scss" scoped>
 .error-not-found__content {

--- a/src/pages/ExpensesPage.vue
+++ b/src/pages/ExpensesPage.vue
@@ -1,0 +1,347 @@
+<template>
+  <q-pull-to-refresh
+    :disable="$q.screen.gt.sm"
+    @refresh="onRefresh"
+  >
+    <ListPageLayout
+      title="Activity"
+      description="Your spending across all plans"
+      create-button-label="Add Expense"
+      @create="openExpenseDialog"
+    >
+      <SearchAndSort
+        v-model:search-query="searchQuery"
+        v-model:sort-by="sortBy"
+        search-placeholder="Search expenses..."
+        :sort-options="sortOptions"
+      />
+
+      <!-- Category filter chips -->
+      <div
+        v-if="availableCategories.length > 1"
+        class="category-filter-row q-mb-md"
+      >
+        <q-chip
+          v-for="category in availableCategories"
+          :key="category.id"
+          clickable
+          :class="{ 'category-filter-chip--active': selectedCategoryId === category.id }"
+          class="category-filter-chip"
+          @click="toggleCategory(category.id)"
+        >
+          <q-icon
+            :name="category.icon || 'eva-folder-outline'"
+            size="14px"
+            class="q-mr-xs"
+          />
+          {{ category.name }}
+        </q-chip>
+      </div>
+
+      <!-- Loading skeleton -->
+      <q-card
+        v-if="isPending"
+        :bordered="$q.dark.isActive"
+        class="shadow-1"
+      >
+        <q-card-section>
+          <div
+            v-for="n in 6"
+            :key="n"
+            class="row items-center q-py-sm"
+          >
+            <q-skeleton
+              type="QAvatar"
+              size="32px"
+              class="q-mr-md"
+            />
+            <div class="col">
+              <q-skeleton
+                type="text"
+                width="50%"
+              />
+              <q-skeleton
+                type="text"
+                width="30%"
+              />
+            </div>
+            <q-skeleton
+              type="text"
+              width="60px"
+            />
+          </div>
+        </q-card-section>
+      </q-card>
+
+      <!-- Day-grouped expense list -->
+      <template v-else-if="dayGroups.length > 0">
+        <div
+          v-for="group in dayGroups"
+          :key="group.date"
+          class="q-mb-md"
+        >
+          <div class="row items-baseline justify-between q-px-sm q-mb-xs">
+            <h2 class="text-subtitle2 text-weight-medium q-my-none">
+              {{ group.label }}
+            </h2>
+            <span class="text-caption text-amount">{{ group.totalLabel }}</span>
+          </div>
+          <q-card
+            :bordered="$q.dark.isActive"
+            class="shadow-1"
+          >
+            <q-list separator>
+              <ExpenseListItem
+                v-for="expense in group.expenses"
+                :key="expense.id"
+                :expense="expense"
+                :currency="expenseCurrency(expense)"
+                :can-edit="true"
+                show-category
+                :category-name="expense.plans?.name || ''"
+                :category-color="expense.categories?.color || '#666'"
+                :category-icon="expense.categories?.icon || 'eva-folder-outline'"
+              />
+            </q-list>
+          </q-card>
+        </div>
+      </template>
+
+      <!-- Empty: filtered -->
+      <EmptyState
+        v-else-if="hasActiveFilter"
+        :has-search-query="true"
+        search-icon="eva-search-outline"
+        search-title="No matching expenses"
+        search-description="Try a different search or clear the filters."
+        create-button-label="Add Expense"
+        @clear-search="clearFilters"
+        @create="openExpenseDialog"
+      />
+
+      <!-- Empty: no expenses at all -->
+      <EmptyExpensesState
+        v-else
+        @add-expense="openExpenseDialog"
+      />
+
+      <!-- Expense Registration Dialog -->
+      <ExpenseRegistrationDialog
+        v-if="hasOpenedExpenseDialog"
+        v-model="showExpenseDialog"
+        auto-select-recent-plan
+        @expense-created="showExpenseDialog = false"
+      />
+    </ListPageLayout>
+  </q-pull-to-refresh>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useMeta, useQuasar } from 'quasar'
+
+import ListPageLayout from 'src/layouts/ListPageLayout.vue'
+import SearchAndSort from 'src/components/shared/SearchAndSort.vue'
+import EmptyState from 'src/components/shared/EmptyState.vue'
+import EmptyExpensesState from 'src/components/expenses/EmptyExpensesState.vue'
+import ExpenseListItem from 'src/components/expenses/ExpenseListItem.vue'
+import ExpenseRegistrationDialog from 'src/components/expenses/ExpenseRegistrationDialog.vue'
+import { useQueryClient } from '@tanstack/vue-query'
+import { useRecentExpensesQuery } from 'src/queries/expenses'
+import { queryKeys } from 'src/queries/query-keys'
+import { useUserStore } from 'src/stores/user'
+import { usePreferencesStore } from 'src/stores/preferences'
+import { formatCurrency, formatCurrencyPrivate, type CurrencyCode } from 'src/utils/currency'
+import { formatDateRelative } from 'src/utils/date'
+import type { ExpenseWithCategoryAndPlan } from 'src/api'
+
+useMeta({ title: 'Activity' })
+
+const RECENT_EXPENSES_LIMIT = 200
+
+const $q = useQuasar()
+const userStore = useUserStore()
+const preferencesStore = usePreferencesStore()
+
+const userId = computed(() => userStore.userProfile?.id)
+const { expenses, isPending } = useRecentExpensesQuery(userId, RECENT_EXPENSES_LIMIT)
+const queryClient = useQueryClient()
+
+async function onRefresh(done: () => void) {
+  try {
+    await queryClient.invalidateQueries({ queryKey: queryKeys.expenses.recentAll() })
+  } finally {
+    done()
+  }
+}
+
+const searchQuery = ref('')
+const sortBy = ref('date-desc')
+const selectedCategoryId = ref<string | null>(null)
+
+const sortOptions = [
+  { label: 'Newest first', value: 'date-desc' },
+  { label: 'Oldest first', value: 'date-asc' },
+  { label: 'Highest amount', value: 'amount-desc' },
+  { label: 'Lowest amount', value: 'amount-asc' },
+]
+
+const hasOpenedExpenseDialog = ref(false)
+const showExpenseDialog = ref(false)
+
+function openExpenseDialog() {
+  hasOpenedExpenseDialog.value = true
+  showExpenseDialog.value = true
+}
+
+const availableCategories = computed(() => {
+  const seen = new Map<string, { id: string; name: string; icon: string | null }>()
+  expenses.value.forEach((expense) => {
+    if (expense.categories && !seen.has(expense.categories.id)) {
+      seen.set(expense.categories.id, {
+        id: expense.categories.id,
+        name: expense.categories.name,
+        icon: expense.categories.icon,
+      })
+    }
+  })
+  return Array.from(seen.values()).sort((a, b) => a.name.localeCompare(b.name))
+})
+
+function toggleCategory(categoryId: string) {
+  selectedCategoryId.value = selectedCategoryId.value === categoryId ? null : categoryId
+}
+
+const hasActiveFilter = computed(() => !!searchQuery.value || !!selectedCategoryId.value)
+
+function clearFilters() {
+  searchQuery.value = ''
+  selectedCategoryId.value = null
+}
+
+const filteredExpenses = computed(() => {
+  let result = expenses.value
+
+  if (selectedCategoryId.value) {
+    result = result.filter((expense) => expense.category_id === selectedCategoryId.value)
+  }
+
+  const query = searchQuery.value.trim().toLowerCase()
+  if (query) {
+    result = result.filter(
+      (expense) =>
+        expense.name.toLowerCase().includes(query) ||
+        expense.categories?.name.toLowerCase().includes(query) ||
+        expense.plans?.name.toLowerCase().includes(query),
+    )
+  }
+
+  const sorted = [...result]
+  switch (sortBy.value) {
+    case 'date-asc':
+      sorted.sort((a, b) => a.expense_date.localeCompare(b.expense_date))
+      break
+    case 'amount-desc':
+      sorted.sort((a, b) => b.amount - a.amount)
+      break
+    case 'amount-asc':
+      sorted.sort((a, b) => a.amount - b.amount)
+      break
+    default:
+      sorted.sort((a, b) => b.expense_date.localeCompare(a.expense_date))
+  }
+
+  return sorted
+})
+
+type DayGroup = {
+  date: string
+  label: string
+  totalLabel: string
+  expenses: ExpenseWithCategoryAndPlan[]
+}
+
+const isDateSort = computed(() => sortBy.value === 'date-desc' || sortBy.value === 'date-asc')
+
+const dayGroups = computed((): DayGroup[] => {
+  if (filteredExpenses.value.length === 0) return []
+
+  // Amount sorts render as a single flat group
+  if (!isDateSort.value) {
+    return [
+      {
+        date: 'all',
+        label: 'All expenses',
+        totalLabel: groupTotalLabel(filteredExpenses.value),
+        expenses: filteredExpenses.value,
+      },
+    ]
+  }
+
+  const groups = new Map<string, ExpenseWithCategoryAndPlan[]>()
+  filteredExpenses.value.forEach((expense) => {
+    const day = expense.expense_date.slice(0, 10)
+    const group = groups.get(day)
+    if (group) {
+      group.push(expense)
+    } else {
+      groups.set(day, [expense])
+    }
+  })
+
+  return Array.from(groups.entries()).map(([date, dayExpenses]) => ({
+    date,
+    label: formatDateRelative(date),
+    totalLabel: groupTotalLabel(dayExpenses),
+    expenses: dayExpenses,
+  }))
+})
+
+function expenseCurrency(expense: ExpenseWithCategoryAndPlan): CurrencyCode {
+  return (expense.plans?.currency ?? preferencesStore.currency) as CurrencyCode
+}
+
+function groupTotalLabel(groupExpenses: ExpenseWithCategoryAndPlan[]): string {
+  const first = groupExpenses[0]
+  if (!first) return ''
+
+  const currency = expenseCurrency(first)
+
+  if (preferencesStore.isPrivacyModeEnabled) {
+    return formatCurrencyPrivate(currency)
+  }
+
+  // Mixed currencies within one day can't be summed meaningfully
+  const hasMixedCurrencies = groupExpenses.some((expense) => expenseCurrency(expense) !== currency)
+  if (hasMixedCurrencies) return ''
+
+  const total = groupExpenses.reduce((sum, expense) => sum + expense.amount, 0)
+  return formatCurrency(total, currency)
+}
+</script>
+
+<style lang="scss" scoped>
+.category-filter-row {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  -webkit-overflow-scrolling: touch;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.category-filter-chip {
+  flex: 0 0 auto;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+.category-filter-chip--active {
+  background: hsl(var(--primary) / 0.14);
+  color: hsl(var(--primary));
+  box-shadow: inset 0 0 0 1px hsl(var(--primary) / 0.3);
+}
+</style>

--- a/src/pages/IndexPage.test.ts
+++ b/src/pages/IndexPage.test.ts
@@ -1,13 +1,27 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { it, expect, vi, beforeEach } from 'vitest'
 import { ref, computed } from 'vue'
+import { Screen } from 'quasar'
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest'
 import IndexPage from './IndexPage.vue'
+import { queryKeys } from 'src/queries/query-keys'
 import { createMockPlans, createMockTemplates } from 'test/fixtures'
 
 installQuasarPlugin()
 
 const mockRouterPush = vi.fn()
+
+const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@tanstack/vue-query', async () => {
+  const actual = await vi.importActual('@tanstack/vue-query')
+  return {
+    ...actual,
+    useQueryClient: vi.fn(() => ({
+      invalidateQueries: mockInvalidateQueries,
+    })),
+  }
+})
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({
@@ -134,6 +148,8 @@ function createWrapper() {
         SharePlanDialog: true,
         ShareTemplateDialog: true,
         BudgetOverviewCard: true,
+        TopCategoriesCard: true,
+        RecentActivityCard: true,
         PlanListItem: true,
         TemplateListItem: true,
       },
@@ -141,8 +157,21 @@ function createWrapper() {
   })
 }
 
+function setScreenWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+
+  window.dispatchEvent(new Event('resize'))
+}
+
 beforeEach(() => {
+  Screen.setDebounce(0)
+  setScreenWidth(1280)
   vi.clearAllMocks()
+  mockInvalidateQueries.mockResolvedValue(undefined)
   mockActivePlans.value = createMockPlans()
   mockTemplatesData.value = createMockTemplates()
   mockPlansIsPending.value = true
@@ -278,4 +307,104 @@ it('should hide loading state after data loads', async () => {
   dashboardSections.forEach((section) => {
     expect(section.attributes('loading')).toBe('false')
   })
+})
+
+it('should render budget hero card for the most recently updated plan after loading', async () => {
+  mockPlansIsPending.value = false
+  mockTemplatesIsPending.value = false
+
+  const plans = createMockPlans()
+  const freshestPlan = { ...plans[1]!, updated_at: '2024-02-01T00:00:00Z' }
+  plans[1] = freshestPlan
+  mockActivePlans.value = plans
+
+  const wrapper = createWrapper()
+  await flushPromises()
+
+  const hero = wrapper.findComponent({ name: 'BudgetOverviewCard' })
+  expect(hero.exists()).toBe(true)
+  expect(hero.props('plan')).toMatchObject({ id: freshestPlan.id })
+})
+
+it('should not render budget hero card while loading', () => {
+  const wrapper = createWrapper()
+
+  expect(wrapper.findComponent({ name: 'BudgetOverviewCard' }).exists()).toBe(false)
+  expect(wrapper.findAll('.q-skeleton').length).toBeGreaterThan(0)
+})
+
+it('should render top categories and recent activity cards when plans exist', async () => {
+  mockPlansIsPending.value = false
+  mockTemplatesIsPending.value = false
+
+  const wrapper = createWrapper()
+  await flushPromises()
+
+  expect(wrapper.findComponent({ name: 'TopCategoriesCard' }).exists()).toBe(true)
+  expect(wrapper.findComponent({ name: 'RecentActivityCard' }).exists()).toBe(true)
+})
+
+it('should show standalone empty plans state when not loading and no active plans', async () => {
+  mockPlansIsPending.value = false
+  mockTemplatesIsPending.value = false
+  mockActivePlans.value = []
+
+  const wrapper = createWrapper()
+  await flushPromises()
+
+  expect(wrapper.findComponent({ name: 'EmptyPlansState' }).exists()).toBe(true)
+  expect(wrapper.findComponent({ name: 'BudgetOverviewCard' }).exists()).toBe(false)
+  expect(wrapper.findComponent({ name: 'TopCategoriesCard' }).exists()).toBe(false)
+  expect(wrapper.findComponent({ name: 'RecentActivityCard' }).exists()).toBe(false)
+})
+
+it('should show compact links instead of full sections on mobile', async () => {
+  setScreenWidth(600)
+  mockPlansIsPending.value = false
+  mockTemplatesIsPending.value = false
+
+  const wrapper = createWrapper()
+  await flushPromises()
+
+  expect(wrapper.findAllComponents({ name: 'DashboardSection' })).toHaveLength(0)
+
+  const items = wrapper.findAllComponents({ name: 'QItem' })
+  const plansItem = items.find((item) => item.text().includes('Active plans'))
+  const templatesItem = items.find((item) => item.text().includes('Templates'))
+
+  expect(plansItem?.props('to')).toBe('/plans')
+  expect(templatesItem?.props('to')).toBe('/templates')
+
+  expect(plansItem?.text()).toContain(String(mockActivePlans.value.length))
+  expect(templatesItem?.text()).toContain(String(mockTemplatesData.value.length))
+})
+
+it('should not show compact links on mobile when there are no active plans', async () => {
+  setScreenWidth(600)
+  mockPlansIsPending.value = false
+  mockTemplatesIsPending.value = false
+  mockActivePlans.value = []
+
+  const wrapper = createWrapper()
+  await flushPromises()
+
+  expect(wrapper.findAllComponents({ name: 'QItem' })).toHaveLength(0)
+  expect(wrapper.findComponent({ name: 'EmptyPlansState' }).exists()).toBe(true)
+})
+
+it('should invalidate plans, templates and recent expenses queries on pull-to-refresh', async () => {
+  const wrapper = createWrapper()
+
+  const pullToRefresh = wrapper.findComponent({ name: 'QPullToRefresh' })
+  expect(pullToRefresh.exists()).toBe(true)
+
+  const done = vi.fn()
+  pullToRefresh.vm.$emit('refresh', done)
+  await vi.waitFor(() => {
+    expect(done).toHaveBeenCalledOnce()
+  })
+
+  expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.plans.all })
+  expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.templates.all })
+  expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.expenses.recentAll() })
 })

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -1,157 +1,251 @@
 <template>
-  <section class="page-content-spacing">
-    <div class="row justify-center">
-      <div class="col-12 col-lg-10 col-xl-8">
-        <!-- Dashboard Header -->
-        <DashboardHeader />
+  <q-pull-to-refresh
+    :disable="$q.screen.gt.sm"
+    @refresh="onRefresh"
+  >
+    <section class="page-content-spacing">
+      <div class="row justify-center">
+        <div class="col-12 col-lg-10 col-xl-8">
+          <!-- Dashboard Header -->
+          <DashboardHeader />
 
-        <!-- Quick Actions Section (hidden on mobile) -->
-        <QuickActionsGrid
-          v-if="$q.screen.gt.sm"
-          @add-expense="openExpenseDialog"
-        />
+          <!-- Quick Actions Section (hidden on mobile) -->
+          <QuickActionsGrid
+            v-if="$q.screen.gt.sm"
+            @add-expense="openExpenseDialog"
+          />
 
-        <!-- Budget Overview Card -->
-        <BudgetOverviewCard
-          v-if="primaryPlan && !isLoading"
-          :plan="primaryPlan"
-          class="section-spacing"
-          @click="goToPlan"
-        />
+          <!-- Budget Hero Card -->
+          <BudgetOverviewCard
+            v-if="primaryPlan && !isLoading"
+            :plan="primaryPlan"
+            class="section-spacing"
+            @click="goToPlan"
+          />
 
-        <!-- Budget Overview Skeleton (shown while loading) -->
-        <q-card
-          v-else-if="isLoading"
-          :bordered="$q.dark.isActive"
-          class="shadow-1 section-spacing"
-        >
-          <q-card-section>
-            <div class="row items-center justify-between q-mb-md">
-              <q-skeleton
-                type="text"
-                width="40%"
-              />
-              <q-skeleton
-                type="QChip"
-                width="80px"
-              />
-            </div>
-            <div class="row q-col-gutter-sm q-mb-sm">
-              <div
-                v-for="n in 3"
-                :key="n"
-                class="col"
-              >
+          <!-- Budget Hero Skeleton (shown while loading) -->
+          <q-card
+            v-else-if="isLoading"
+            :bordered="$q.dark.isActive"
+            class="shadow-1 section-spacing"
+          >
+            <q-card-section>
+              <div class="row items-center justify-between q-mb-md">
                 <q-skeleton
                   type="text"
-                  width="60%"
+                  width="40%"
                 />
                 <q-skeleton
-                  type="text"
-                  width="80%"
+                  type="QChip"
+                  width="80px"
                 />
               </div>
-            </div>
-            <q-skeleton
-              type="rect"
-              height="8px"
-            />
-            <q-skeleton
-              type="text"
-              width="50%"
-              class="q-mt-xs"
-            />
-          </q-card-section>
-        </q-card>
+              <q-skeleton
+                type="text"
+                width="55%"
+                height="48px"
+              />
+              <q-skeleton
+                type="rect"
+                height="8px"
+                class="q-mt-md"
+              />
+              <q-skeleton
+                type="text"
+                width="50%"
+                class="q-mt-xs"
+              />
+            </q-card-section>
+          </q-card>
 
-        <!-- Active Plans Section -->
-        <DashboardSection
-          title="Active Plans"
-          icon="eva-calendar-outline"
-          :items="recentActivePlans"
-          :count="activePlansCount"
-          :loading="isLoading"
-          view-all-route="/plans"
-          :max-displayed="maxDisplayedItems"
-          container-class="section-spacing"
-        >
-          <template #card="{ item }">
-            <PlanCard
-              :plan="item"
-              @edit="goToPlan"
-              @share="openSharePlanDialog"
-            />
-          </template>
-          <template #list-item="{ item }">
-            <PlanListItem
-              :plan="item"
-              @click="goToPlan"
-            />
-          </template>
-          <template #empty>
-            <EmptyPlansState />
-          </template>
-        </DashboardSection>
+          <!-- Top Categories (primary plan) -->
+          <TopCategoriesCard
+            v-if="primaryPlan && !isLoading"
+            :plan="primaryPlan"
+            class="section-spacing"
+            @click="goToPlan"
+          />
 
-        <!-- Recent Templates Section -->
-        <DashboardSection
-          title="Recent Templates"
-          icon="eva-file-text-outline"
-          :items="recentTemplates"
-          :count="templatesCount"
-          :loading="isLoading"
-          view-all-route="/templates"
-          :max-displayed="maxDisplayedItems"
-          container-class="section-spacing"
-        >
-          <template #card="{ item }">
-            <TemplateCard
-              :template="item"
-              @edit="goToTemplate"
-              @share="openShareTemplateDialog"
-            />
-          </template>
-          <template #list-item="{ item }">
-            <TemplateListItem
-              :template="item"
-              @click="goToTemplate"
-            />
-          </template>
-          <template #empty>
-            <EmptyTemplatesState />
-          </template>
-        </DashboardSection>
+          <!-- Recent Activity -->
+          <RecentActivityCard
+            v-if="activePlansCount > 0"
+            class="section-spacing"
+          />
+
+          <!-- First-run: no active plans -->
+          <EmptyPlansState
+            v-if="!isLoading && activePlansCount === 0"
+            class="section-spacing"
+          />
+
+          <!-- Mobile: compact links instead of full card sections -->
+          <q-card
+            v-if="$q.screen.lt.md && activePlansCount > 0"
+            :bordered="$q.dark.isActive"
+            class="shadow-1 section-spacing"
+          >
+            <q-list separator>
+              <q-item
+                clickable
+                to="/plans"
+              >
+                <q-item-section
+                  avatar
+                  class="min-w-auto"
+                >
+                  <q-icon
+                    name="eva-calendar-outline"
+                    color="primary"
+                    size="22px"
+                  />
+                </q-item-section>
+                <q-item-section>
+                  <q-item-label class="text-weight-medium">Active plans</q-item-label>
+                </q-item-section>
+                <q-item-section side>
+                  <div class="row items-center q-gutter-xs">
+                    <q-badge
+                      color="primary"
+                      rounded
+                    >
+                      {{ activePlansCount }}
+                    </q-badge>
+                    <q-icon
+                      name="eva-chevron-right-outline"
+                      size="18px"
+                    />
+                  </div>
+                </q-item-section>
+              </q-item>
+
+              <q-item
+                clickable
+                to="/templates"
+              >
+                <q-item-section
+                  avatar
+                  class="min-w-auto"
+                >
+                  <q-icon
+                    name="eva-file-text-outline"
+                    color="primary"
+                    size="22px"
+                  />
+                </q-item-section>
+                <q-item-section>
+                  <q-item-label class="text-weight-medium">Templates</q-item-label>
+                </q-item-section>
+                <q-item-section side>
+                  <div class="row items-center q-gutter-xs">
+                    <q-badge
+                      color="primary"
+                      rounded
+                    >
+                      {{ templatesCount }}
+                    </q-badge>
+                    <q-icon
+                      name="eva-chevron-right-outline"
+                      size="18px"
+                    />
+                  </div>
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </q-card>
+
+          <!-- Desktop: full Active Plans section -->
+          <DashboardSection
+            v-if="$q.screen.gt.sm && activePlansCount > 0"
+            title="Active Plans"
+            icon="eva-calendar-outline"
+            :items="recentActivePlans"
+            :count="activePlansCount"
+            :loading="isLoading"
+            view-all-route="/plans"
+            :max-displayed="maxDisplayedItems"
+            container-class="section-spacing"
+          >
+            <template #card="{ item }">
+              <PlanCard
+                :plan="item"
+                @edit="goToPlan"
+                @share="openSharePlanDialog"
+              />
+            </template>
+            <template #list-item="{ item }">
+              <PlanListItem
+                :plan="item"
+                @click="goToPlan"
+              />
+            </template>
+            <template #empty>
+              <EmptyPlansState />
+            </template>
+          </DashboardSection>
+
+          <!-- Desktop: full Recent Templates section -->
+          <DashboardSection
+            v-if="$q.screen.gt.sm"
+            title="Recent Templates"
+            icon="eva-file-text-outline"
+            :items="recentTemplates"
+            :count="templatesCount"
+            :loading="isLoading"
+            view-all-route="/templates"
+            :max-displayed="maxDisplayedItems"
+            container-class="section-spacing"
+          >
+            <template #card="{ item }">
+              <TemplateCard
+                :template="item"
+                @edit="goToTemplate"
+                @share="openShareTemplateDialog"
+              />
+            </template>
+            <template #list-item="{ item }">
+              <TemplateListItem
+                :template="item"
+                @click="goToTemplate"
+              />
+            </template>
+            <template #empty>
+              <EmptyTemplatesState />
+            </template>
+          </DashboardSection>
+        </div>
       </div>
-    </div>
 
-    <!-- Expense Registration Dialog -->
-    <ExpenseRegistrationDialog
-      v-if="hasOpenedExpenseDialog"
-      v-model="showExpenseDialog"
-      auto-select-recent-plan
-      @expense-created="onExpenseCreated"
-    />
+      <!-- Expense Registration Dialog -->
+      <ExpenseRegistrationDialog
+        v-if="hasOpenedExpenseDialog"
+        v-model="showExpenseDialog"
+        auto-select-recent-plan
+        @expense-created="onExpenseCreated"
+      />
 
-    <!-- Share Dialogs -->
-    <SharePlanDialog
-      v-if="sharePlanId"
-      v-model="showSharePlanDialog"
-      :plan-id="sharePlanId"
-      :owner-user-id="activePlans.find((p) => p.id === sharePlanId)?.owner_id"
-    />
-    <ShareTemplateDialog
-      v-if="shareTemplateId"
-      v-model="showShareTemplateDialog"
-      :template-id="shareTemplateId"
-      :owner-user-id="templates.find((t) => t.id === shareTemplateId)?.owner_id"
-    />
-  </section>
+      <!-- Share Dialogs -->
+      <SharePlanDialog
+        v-if="sharePlanId"
+        v-model="showSharePlanDialog"
+        :plan-id="sharePlanId"
+        :owner-user-id="activePlans.find((p) => p.id === sharePlanId)?.owner_id"
+      />
+      <ShareTemplateDialog
+        v-if="shareTemplateId"
+        v-model="showShareTemplateDialog"
+        :template-id="shareTemplateId"
+        :owner-user-id="templates.find((t) => t.id === shareTemplateId)?.owner_id"
+      />
+    </section>
+  </q-pull-to-refresh>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useMeta } from 'quasar'
 import { useRouter } from 'vue-router'
+import { useQueryClient } from '@tanstack/vue-query'
+import { queryKeys } from 'src/queries/query-keys'
 
 useMeta({ title: 'Home' })
 import { usePlansQuery } from 'src/queries/plans'
@@ -162,6 +256,8 @@ import DashboardHeader from 'src/components/dashboard/DashboardHeader.vue'
 import QuickActionsGrid from 'src/components/dashboard/QuickActionsGrid.vue'
 import DashboardSection from 'src/components/dashboard/DashboardSection.vue'
 import BudgetOverviewCard from 'src/components/dashboard/BudgetOverviewCard.vue'
+import TopCategoriesCard from 'src/components/dashboard/TopCategoriesCard.vue'
+import RecentActivityCard from 'src/components/dashboard/RecentActivityCard.vue'
 import PlanListItem from 'src/components/dashboard/PlanListItem.vue'
 import TemplateListItem from 'src/components/dashboard/TemplateListItem.vue'
 import EmptyPlansState from 'src/components/dashboard/EmptyPlansState.vue'
@@ -174,7 +270,20 @@ import ShareTemplateDialog from 'src/components/templates/ShareTemplateDialog.vu
 
 const router = useRouter()
 const userStore = useUserStore()
+const queryClient = useQueryClient()
 const userId = computed(() => userStore.userProfile?.id)
+
+async function onRefresh(done: () => void) {
+  try {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.plans.all }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.templates.all }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.expenses.recentAll() }),
+    ])
+  } finally {
+    done()
+  }
+}
 
 const { activePlans, isPending: isPlansLoading } = usePlansQuery(userId)
 const { templates, isPending: isTemplatesLoading, templatesCount } = useTemplatesQuery(userId)

--- a/src/pages/PlansPage.test.ts
+++ b/src/pages/PlansPage.test.ts
@@ -2,10 +2,24 @@ import { mount } from '@vue/test-utils'
 import { it, expect, vi, beforeEach } from 'vitest'
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest'
 import { ref, computed } from 'vue'
+import { Screen } from 'quasar'
 import PlansPage from './PlansPage.vue'
 import { usePlans } from 'src/composables/usePlans'
+import { queryKeys } from 'src/queries/query-keys'
 import type { PlanWithPermission } from 'src/api'
 import { getExpensesByPlan, getPlanExpenseSummary, getPlanWithItems } from 'src/api'
+
+const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@tanstack/vue-query', async () => {
+  const actual = await vi.importActual('@tanstack/vue-query')
+  return {
+    ...actual,
+    useQueryClient: vi.fn(() => ({
+      invalidateQueries: mockInvalidateQueries,
+    })),
+  }
+})
 
 vi.mock('src/api', async () => {
   const actual = await vi.importActual('src/api')
@@ -146,6 +160,7 @@ const EmptyStateStub = {
     </div>
   `,
   props: [
+    'illustration',
     'hasSearchQuery',
     'searchIcon',
     'emptyIcon',
@@ -321,8 +336,21 @@ function createWrapper(
   }
 }
 
+function setScreenWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+
+  window.dispatchEvent(new Event('resize'))
+}
+
 beforeEach(() => {
+  Screen.setDebounce(0)
+  setScreenWidth(1280)
   vi.clearAllMocks()
+  mockInvalidateQueries.mockResolvedValue(undefined)
 })
 
 it('should mount component properly', () => {
@@ -425,6 +453,7 @@ it('should show empty state when no plans and not loading', () => {
 
   const emptyState = wrapper.findComponent(EmptyStateStub)
   expect(emptyState.exists()).toBe(true)
+  expect(emptyState.props('illustration')).toBe('plan')
   expect(emptyState.props('hasSearchQuery')).toBe(false)
   expect(emptyState.props('emptyTitle')).toBe('No plans yet')
   expect(emptyState.props('emptyDescription')).toBe(
@@ -675,4 +704,35 @@ it('should close share dialog when model value changes', async () => {
 
   shareDialog = wrapper.findComponent(SharePlanDialogStub)
   expect(shareDialog.attributes('data-model-value')).toBe('false')
+})
+
+it('should show browse templates link on mobile only', async () => {
+  setScreenWidth(600)
+  const { wrapper: mobileWrapper } = createWrapper()
+  await mobileWrapper.vm.$nextTick()
+
+  const mobileBrowseButton = mobileWrapper.find('[data-label="Browse templates"]')
+  expect(mobileBrowseButton.exists()).toBe(true)
+  expect(mobileBrowseButton.attributes('to')).toBe('/templates')
+
+  setScreenWidth(1280)
+  const { wrapper: desktopWrapper } = createWrapper()
+  await desktopWrapper.vm.$nextTick()
+
+  expect(desktopWrapper.find('[data-label="Browse templates"]').exists()).toBe(false)
+})
+
+it('should invalidate plans queries on pull-to-refresh', async () => {
+  const { wrapper } = createWrapper()
+
+  const pullToRefresh = wrapper.findComponent({ name: 'QPullToRefresh' })
+  expect(pullToRefresh.exists()).toBe(true)
+
+  const done = vi.fn()
+  pullToRefresh.vm.$emit('refresh', done)
+  await vi.waitFor(() => {
+    expect(done).toHaveBeenCalledOnce()
+  })
+
+  expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.plans.all })
 })

--- a/src/pages/PlansPage.vue
+++ b/src/pages/PlansPage.vue
@@ -1,58 +1,78 @@
 <template>
-  <ListPageLayout
-    title="Plans"
-    description="Manage your financial plans and track your progress"
-    create-button-label="Create Plan"
-    @create="goToNew"
+  <q-pull-to-refresh
+    :disable="$q.screen.gt.sm"
+    @refresh="onRefresh"
   >
-    <SearchAndSort
-      v-model:search-query="searchQuery"
-      v-model:sort-by="sortBy"
-      search-placeholder="Search plans..."
-      :sort-options="sortOptions"
-    />
-
-    <ListPageSkeleton v-if="areItemsLoading" />
-
-    <PlansGroup
-      v-else-if="hasItems"
-      title="My Plans"
-      :plans="allFilteredAndSortedItems"
-      @edit="viewItem"
-      @export="openExportDialog"
-      @delete="handleDeletePlan"
-      @share="openShareDialog"
-      @cancel="cancelPlan"
-    />
-
-    <EmptyState
-      v-else
-      :has-search-query="!!searchQuery"
-      :search-icon="emptyStateConfig.searchIcon"
-      :empty-icon="emptyStateConfig.emptyIcon"
-      :search-title="emptyStateConfig.searchTitle"
-      :empty-title="emptyStateConfig.emptyTitle"
-      :search-description="emptyStateConfig.searchDescription"
-      :empty-description="emptyStateConfig.emptyDescription"
-      :create-button-label="emptyStateConfig.createLabel"
-      @clear-search="clearSearch"
+    <ListPageLayout
+      title="Plans"
+      description="Manage your financial plans and track your progress"
+      create-button-label="Create Plan"
       @create="goToNew"
-    />
+    >
+      <SearchAndSort
+        v-model:search-query="searchQuery"
+        v-model:sort-by="sortBy"
+        search-placeholder="Search plans..."
+        :sort-options="sortOptions"
+      />
 
-    <!-- Share Plan Dialog -->
-    <SharePlanDialog
-      v-if="sharePlanId"
-      v-model="isShareDialogOpen"
-      :plan-id="sharePlanId"
-      :owner-user-id="sharePlanOwnerId"
-      @shared="isShareDialogOpen = false"
-    />
+      <!-- Mobile: templates live under Plans since the bottom nav slot went to Activity -->
+      <q-btn
+        v-if="$q.screen.lt.md"
+        flat
+        no-caps
+        dense
+        color="primary"
+        icon="eva-file-text-outline"
+        icon-right="eva-chevron-right-outline"
+        label="Browse templates"
+        class="q-mb-sm"
+        to="/templates"
+      />
 
-    <ExportDialog
-      v-model="isExportDialogOpen"
-      @select-format="handlePlanExport"
-    />
-  </ListPageLayout>
+      <ListPageSkeleton v-if="areItemsLoading" />
+
+      <PlansGroup
+        v-else-if="hasItems"
+        title="My Plans"
+        :plans="allFilteredAndSortedItems"
+        @edit="viewItem"
+        @export="openExportDialog"
+        @delete="handleDeletePlan"
+        @share="openShareDialog"
+        @cancel="cancelPlan"
+      />
+
+      <EmptyState
+        v-else
+        illustration="plan"
+        :has-search-query="!!searchQuery"
+        :search-icon="emptyStateConfig.searchIcon"
+        :empty-icon="emptyStateConfig.emptyIcon"
+        :search-title="emptyStateConfig.searchTitle"
+        :empty-title="emptyStateConfig.emptyTitle"
+        :search-description="emptyStateConfig.searchDescription"
+        :empty-description="emptyStateConfig.emptyDescription"
+        :create-button-label="emptyStateConfig.createLabel"
+        @clear-search="clearSearch"
+        @create="goToNew"
+      />
+
+      <!-- Share Plan Dialog -->
+      <SharePlanDialog
+        v-if="sharePlanId"
+        v-model="isShareDialogOpen"
+        :plan-id="sharePlanId"
+        :owner-user-id="sharePlanOwnerId"
+        @shared="isShareDialogOpen = false"
+      />
+
+      <ExportDialog
+        v-model="isExportDialogOpen"
+        @select-format="handlePlanExport"
+      />
+    </ListPageLayout>
+  </q-pull-to-refresh>
 </template>
 
 <script setup lang="ts">
@@ -69,6 +89,8 @@ import PlansGroup from 'src/components/plans/PlansGroup.vue'
 import SharePlanDialog from 'src/components/plans/SharePlanDialog.vue'
 import ExportDialog from 'src/components/shared/ExportDialog.vue'
 import { usePlans } from 'src/composables/usePlans'
+import { useQueryClient } from '@tanstack/vue-query'
+import { queryKeys } from 'src/queries/query-keys'
 import { useCategoriesQuery } from 'src/queries/categories'
 import { useUserStore } from 'src/stores/user'
 import { useBanner } from 'src/composables/useBanner'
@@ -99,6 +121,15 @@ const {
 const { categories } = useCategoriesQuery()
 const userStore = useUserStore()
 const { showError, showSuccess } = useBanner()
+const queryClient = useQueryClient()
+
+async function onRefresh(done: () => void) {
+  try {
+    await queryClient.invalidateQueries({ queryKey: queryKeys.plans.all })
+  } finally {
+    done()
+  }
+}
 
 const isShareDialogOpen = ref(false)
 const isExportDialogOpen = ref(false)

--- a/src/pages/TemplatesPage.test.ts
+++ b/src/pages/TemplatesPage.test.ts
@@ -4,6 +4,7 @@ import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-v
 import { ref, computed } from 'vue'
 import TemplatesPage from './TemplatesPage.vue'
 import { useTemplates } from 'src/composables/useTemplates'
+import { queryKeys } from 'src/queries/query-keys'
 import type { TemplateWithPermission } from 'src/api'
 import { setupTestingPinia } from 'test/helpers/pinia-mocks'
 import { createMockTemplates } from 'test/fixtures'
@@ -14,6 +15,18 @@ vi.mock('src/api', async () => {
   return {
     ...actual,
     getTemplateWithItems: vi.fn(),
+  }
+})
+
+const mockInvalidateQueries = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@tanstack/vue-query', async () => {
+  const actual = await vi.importActual('@tanstack/vue-query')
+  return {
+    ...actual,
+    useQueryClient: vi.fn(() => ({
+      invalidateQueries: mockInvalidateQueries,
+    })),
   }
 })
 
@@ -145,6 +158,7 @@ const EmptyStateStub = {
     </div>
   `,
   props: [
+    'illustration',
     'hasSearchQuery',
     'searchIcon',
     'emptyIcon',
@@ -283,6 +297,7 @@ function createWrapper(
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockInvalidateQueries.mockResolvedValue(undefined)
 })
 
 it('should mount component properly', () => {
@@ -386,6 +401,7 @@ it('should show empty state when no templates and not loading', () => {
 
   const emptyState = wrapper.findComponent(EmptyStateStub)
   expect(emptyState.exists()).toBe(true)
+  expect(emptyState.props('illustration')).toBe('template')
   expect(emptyState.props('hasSearchQuery')).toBe(false)
   expect(emptyState.props('emptyTitle')).toBe('No templates yet')
   expect(emptyState.props('emptyDescription')).toBe(
@@ -608,4 +624,19 @@ it('should close share dialog when model value changes', async () => {
 
   shareDialog = wrapper.findComponent(ShareTemplateDialogStub)
   expect(shareDialog.attributes('data-model-value')).toBe('false')
+})
+
+it('should invalidate templates queries on pull-to-refresh', async () => {
+  const { wrapper } = createWrapper()
+
+  const pullToRefresh = wrapper.findComponent({ name: 'QPullToRefresh' })
+  expect(pullToRefresh.exists()).toBe(true)
+
+  const done = vi.fn()
+  pullToRefresh.vm.$emit('refresh', done)
+  await vi.waitFor(() => {
+    expect(done).toHaveBeenCalledOnce()
+  })
+
+  expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.templates.all })
 })

--- a/src/pages/TemplatesPage.vue
+++ b/src/pages/TemplatesPage.vue
@@ -1,57 +1,63 @@
 <template>
-  <ListPageLayout
-    title="Templates"
-    description="Manage your templates and create new ones"
-    create-button-label="Create Template"
-    @create="goToNew"
+  <q-pull-to-refresh
+    :disable="$q.screen.gt.sm"
+    @refresh="onRefresh"
   >
-    <SearchAndSort
-      v-model:search-query="searchQuery"
-      v-model:sort-by="sortBy"
-      search-placeholder="Search templates..."
-      :sort-options="sortOptions"
-    />
-
-    <ListPageSkeleton v-if="areItemsLoading" />
-
-    <TemplatesGroup
-      v-else-if="hasItems"
-      title="My Templates"
-      :templates="allFilteredAndSortedItems"
-      @edit="viewItem"
-      @export="openExportDialog"
-      @delete="deleteItem"
-      @share="openShareDialog"
-    />
-
-    <EmptyState
-      v-else
-      :has-search-query="!!searchQuery"
-      :search-icon="emptyStateConfig.searchIcon"
-      :empty-icon="emptyStateConfig.emptyIcon"
-      :search-title="emptyStateConfig.searchTitle"
-      :empty-title="emptyStateConfig.emptyTitle"
-      :search-description="emptyStateConfig.searchDescription"
-      :empty-description="emptyStateConfig.emptyDescription"
-      :create-button-label="emptyStateConfig.createLabel"
-      @clear-search="clearSearch"
+    <ListPageLayout
+      title="Templates"
+      description="Manage your templates and create new ones"
+      create-button-label="Create Template"
       @create="goToNew"
-    />
+    >
+      <SearchAndSort
+        v-model:search-query="searchQuery"
+        v-model:sort-by="sortBy"
+        search-placeholder="Search templates..."
+        :sort-options="sortOptions"
+      />
 
-    <!-- Share Template Dialog -->
-    <ShareTemplateDialog
-      v-if="shareTemplateId"
-      v-model="isShareDialogOpen"
-      :template-id="shareTemplateId"
-      :owner-user-id="shareTemplateOwnerId"
-      @shared="isShareDialogOpen = false"
-    />
+      <ListPageSkeleton v-if="areItemsLoading" />
 
-    <ExportDialog
-      v-model="isExportDialogOpen"
-      @select-format="handleTemplateExport"
-    />
-  </ListPageLayout>
+      <TemplatesGroup
+        v-else-if="hasItems"
+        title="My Templates"
+        :templates="allFilteredAndSortedItems"
+        @edit="viewItem"
+        @export="openExportDialog"
+        @delete="deleteItem"
+        @share="openShareDialog"
+      />
+
+      <EmptyState
+        v-else
+        illustration="template"
+        :has-search-query="!!searchQuery"
+        :search-icon="emptyStateConfig.searchIcon"
+        :empty-icon="emptyStateConfig.emptyIcon"
+        :search-title="emptyStateConfig.searchTitle"
+        :empty-title="emptyStateConfig.emptyTitle"
+        :search-description="emptyStateConfig.searchDescription"
+        :empty-description="emptyStateConfig.emptyDescription"
+        :create-button-label="emptyStateConfig.createLabel"
+        @clear-search="clearSearch"
+        @create="goToNew"
+      />
+
+      <!-- Share Template Dialog -->
+      <ShareTemplateDialog
+        v-if="shareTemplateId"
+        v-model="isShareDialogOpen"
+        :template-id="shareTemplateId"
+        :owner-user-id="shareTemplateOwnerId"
+        @shared="isShareDialogOpen = false"
+      />
+
+      <ExportDialog
+        v-model="isExportDialogOpen"
+        @select-format="handleTemplateExport"
+      />
+    </ListPageLayout>
+  </q-pull-to-refresh>
 </template>
 
 <script setup lang="ts">
@@ -68,6 +74,8 @@ import TemplatesGroup from 'src/components/templates/TemplatesGroup.vue'
 import ShareTemplateDialog from 'src/components/templates/ShareTemplateDialog.vue'
 import ExportDialog from 'src/components/shared/ExportDialog.vue'
 import { useTemplates } from 'src/composables/useTemplates'
+import { useQueryClient } from '@tanstack/vue-query'
+import { queryKeys } from 'src/queries/query-keys'
 import { useCategoriesQuery } from 'src/queries/categories'
 import { useUserStore } from 'src/stores/user'
 import { useBanner } from 'src/composables/useBanner'
@@ -92,6 +100,15 @@ const {
   clearSearch,
 } = useTemplates()
 const { categories } = useCategoriesQuery()
+const queryClient = useQueryClient()
+
+async function onRefresh(done: () => void) {
+  try {
+    await queryClient.invalidateQueries({ queryKey: queryKeys.templates.all })
+  } finally {
+    done()
+  }
+}
 const userStore = useUserStore()
 const { showError, showSuccess } = useBanner()
 

--- a/src/queries/expenses.ts
+++ b/src/queries/expenses.ts
@@ -4,6 +4,7 @@ import {
   getExpensesByPlan,
   getPlanExpenseSummary,
   getLastExpenseForPlan,
+  getRecentExpensesForUser,
   createExpense,
   createExpenses,
   deleteExpense,
@@ -11,11 +12,13 @@ import {
   getExpensesByDateRange,
   getExpensesByCategory,
   type ExpenseWithCategory,
+  type ExpenseWithCategoryAndPlan,
   type ExpenseInsert,
   type PlanExpenseSummary,
 } from 'src/api'
 import { updatePlanItemCompletion } from 'src/api/plans'
 import { useUserStore } from 'src/stores/user'
+import { useInstallPromptGate } from 'src/composables/useInstallPromptGate'
 import { queryKeys } from './query-keys'
 import {
   createSpecificErrorHandler,
@@ -82,6 +85,24 @@ export function useExpensesByPlanQuery(planId: MaybeRefOrGetter<string | null>) 
   }
 }
 
+export function useRecentExpensesQuery(userId: MaybeRefOrGetter<string | undefined>, limit = 100) {
+  const query = useQuery({
+    queryKey: computed(() => queryKeys.expenses.recent(toValue(userId) ?? '', limit)),
+    queryFn: () => getRecentExpensesForUser(toValue(userId)!, limit),
+    enabled: computed(() => !!toValue(userId)),
+    staleTime: EXPENSES_STALE_TIME_MS,
+    gcTime: EXPENSES_CACHE_TIME_MS,
+    meta: { errorKey: 'EXPENSES.LOAD_FAILED' as const },
+  })
+
+  const expenses = computed((): ExpenseWithCategoryAndPlan[] => query.data.value ?? [])
+
+  return {
+    ...query,
+    expenses,
+  }
+}
+
 export function useExpenseSummaryQuery(planId: MaybeRefOrGetter<string | null>) {
   const query = useQuery({
     queryKey: computed(() => queryKeys.expenses.summary(toValue(planId) ?? '')),
@@ -125,11 +146,15 @@ function invalidateExpenseQueries(queryClient: ReturnType<typeof useQueryClient>
   queryClient.invalidateQueries({
     queryKey: queryKeys.plans.items(planId),
   })
+  queryClient.invalidateQueries({
+    queryKey: queryKeys.expenses.recentAll(),
+  })
 }
 
 export function useCreateExpenseMutation() {
   const queryClient = useQueryClient()
   const userStore = useUserStore()
+  const { markExpenseSaved } = useInstallPromptGate()
 
   return useMutation({
     mutationFn: (expense: ExpenseInput) => {
@@ -138,6 +163,7 @@ export function useCreateExpenseMutation() {
       return createExpense({ ...expense, user_id: userId })
     },
     onSuccess: (_data, vars) => {
+      markExpenseSaved()
       if (vars.plan_id) {
         invalidateExpenseQueries(queryClient, vars.plan_id)
       }
@@ -149,6 +175,7 @@ export function useCreateExpenseMutation() {
 export function useCreateExpensesBatchMutation() {
   const queryClient = useQueryClient()
   const userStore = useUserStore()
+  const { markExpenseSaved } = useInstallPromptGate()
 
   return useMutation({
     mutationFn: (expenses: ExpenseInput[]) => {
@@ -165,6 +192,7 @@ export function useCreateExpensesBatchMutation() {
       )
     },
     onSuccess: (_data, vars) => {
+      markExpenseSaved()
       const planIds = Array.from(
         new Set(
           vars

--- a/src/queries/query-keys.ts
+++ b/src/queries/query-keys.ts
@@ -22,6 +22,9 @@ export const queryKeys = {
   },
   expenses: {
     all: ['expenses'] as const,
+    recentAll: () => [...queryKeys.expenses.all, 'recent'] as const,
+    recent: (userId: string, limit: number) =>
+      [...queryKeys.expenses.recentAll(), userId, limit] as const,
     byPlan: (planId: string) => [...queryKeys.expenses.all, 'by-plan', planId] as const,
     summary: (planId: string) => [...queryKeys.expenses.all, 'summary', planId] as const,
     lastForPlan: (planId: string) => [...queryKeys.expenses.all, 'last', planId] as const,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue'
 import { defineRouter } from '#q-app/wrappers'
 import {
   createMemoryHistory,
@@ -7,6 +8,10 @@ import {
 } from 'vue-router'
 import routes from './routes'
 import { authGuard } from 'src/router/guards/auth'
+
+type DocumentWithViewTransition = Document & {
+  startViewTransition?: (callback: () => Promise<void>) => unknown
+}
 
 export default defineRouter(function (/* { store, ssrContext } */) {
   const createHistory = process.env.SERVER
@@ -27,6 +32,41 @@ export default defineRouter(function (/* { store, ssrContext } */) {
 
   // Add global navigation guard
   Router.beforeEach(authGuard)
+
+  // Same-document View Transitions between routes (progressive enhancement):
+  // hold navigation until the browser snapshots the old view, release the
+  // new-view snapshot once Vue has rendered the target route.
+  let finishViewTransition: (() => void) | undefined
+
+  Router.beforeResolve((to, from) => {
+    if (to.fullPath === from.fullPath) return
+
+    const doc = typeof document !== 'undefined' ? (document as DocumentWithViewTransition) : null
+    const startViewTransition = doc?.startViewTransition?.bind(doc)
+    if (!startViewTransition) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+    return new Promise<void>((resolve) => {
+      startViewTransition(() => {
+        resolve()
+        return new Promise<void>((finish) => {
+          finishViewTransition = finish
+        })
+      })
+    })
+  })
+
+  Router.afterEach(() => {
+    void nextTick(() => {
+      finishViewTransition?.()
+      finishViewTransition = undefined
+    })
+  })
+
+  Router.onError(() => {
+    finishViewTransition?.()
+    finishViewTransition = undefined
+  })
 
   return Router
 })

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -30,6 +30,11 @@ const routes: RouteRecordRaw[] = [
         name: 'template',
       },
       {
+        path: 'expenses',
+        component: () => import('pages/ExpensesPage.vue'),
+        name: 'expenses',
+      },
+      {
         path: 'plans',
         component: () => import('pages/PlansPage.vue'),
         name: 'plans',

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -35,6 +35,19 @@ export function formatCurrency(
   return `${symbol}${formattedAmount}`
 }
 
+/**
+ * Formats an amount with an explicit sign so negative money is never
+ * communicated by color alone: -12.5 -> "−€12.50", 12.5 -> "€12.50".
+ */
+export function formatCurrencyWithSign(
+  amount: number | null | undefined,
+  currencyCode: CurrencyCode,
+): string {
+  const value = amount ?? 0
+  const formatted = formatCurrency(Math.abs(value), currencyCode)
+  return value < 0 ? `−${formatted}` : formatted
+}
+
 export function formatCurrencyPrivate(currencyCode: CurrencyCode): string {
   return `${getCurrencySymbol(currencyCode)}****`
 }


### PR DESCRIPTION
- Dashboard: gradient hero card with animated "Left to spend" metric, top-categories bars, recent activity feed; compact plan/template links on mobile
- New Activity page (/expenses) with day-grouped history, search, sort and category filter chips; bottom nav rebalanced to Home/Plans/+/Activity/Settings
- Design tokens: tabular numerals for amounts, display type scale, chart accent hues, soft semantic surfaces, slate-teal secondary, layered #121212 dark surfaces
- Token migration: legacy grey/static palette classes replaced with theme-aware utilities across ~40 components
- Money semantics: signed amounts and warning icons so over-budget is never color-only (WCAG 1.4.1)
- Identity: liquid-glass detail toolbar and notifications panel, line-art brand illustrations for empty states and 404
- PWA polish: pull-to-refresh on list pages, View Transitions API route animations, install prompt gated behind first saved expense